### PR TITLE
fixing bug when using null values

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function objectMerge(from, to) {
         if (from.hasOwnProperty(key)) {
             if (to.hasOwnProperty(key)) {
                 // Property in destination object set; update its value.
-                if (from[key].constructor === Object) {
+                if (from[key] && from[key].constructor === Object) {
                     to[key] = objectMerge(from[key], to[key]);
                 } else {
                     to[key] = from[key];
@@ -604,6 +604,7 @@ module.exports = {
      * Processes an Object representing a YCB 2.0 Bundle as defined in the spec.
      *
      * @method read
+     * @param bundle {object}
      * @param context {object}
      * @param validate {boolean}
      * @param debug {boolean}
@@ -623,6 +624,7 @@ module.exports = {
      * Like read(), but doesn't merge the found sections.
      *
      * @method readNoMerge
+     * @param bundle {object}
      * @param context {object}
      * @param validate {boolean}
      * @param debug {boolean}

--- a/tests/fixtures/simple-4.json
+++ b/tests/fixtures/simple-4.json
@@ -1,0 +1,20 @@
+[
+    {
+        "settings": ["master"],
+        "foo": null,
+        "bar": 0,
+        "baz": false,
+        "oof": 4,
+        "rab": 5,
+        "zab": 6
+    },
+    {
+        "settings": ["lang:fr"],
+        "foo": 1,
+        "bar": 2,
+        "baz": 3,
+        "oof": null,
+        "rab": 0,
+        "zab": false
+    }
+]

--- a/tests/unit.js
+++ b/tests/unit.js
@@ -266,7 +266,6 @@ suite.add(new Y.Test.Case({
             'lang': 'fr_FR'
         };
         config = libycb.read(bundle, context);
-
         A.areSame('YRB_YAHOO', config.title_key);
         A.areSame('yahoo_FR.png', config.logo);
         A.areSame('http://gb.yahoo.com', config.links.home);
@@ -439,8 +438,27 @@ suite.add(new Y.Test.Case({
 
         A.areNotSame(obj.list, copy.list);
         AA.itemsAreEqual(obj.list, copy.list);
-    }
+    },
 
+    'test objectMerge': function () {
+        var bundle,
+            ycb;
+
+        bundle = readFixtureFile('dimensions.json')
+            .concat(readFixtureFile('simple-4.json'));
+        ycb = new libycb.Ycb(bundle);
+        var config = ycb.read({
+            'lang': 'fr'
+        });
+        OA.areEqual({
+            foo: 1,
+            bar: 2,
+            baz: 3,
+            oof: null,
+            rab: 0,
+            zab: false
+        }, config);
+    }
 
 }));
 


### PR DESCRIPTION
This fixes the issue reported by Daniel when using `null` values that should be override by other values.
