### PR TITLE
Settings Merge Optimizations

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,38 +14,14 @@ var VERSION = '1.0.2',
     SUBMATCH = /\$\$([\w.-_]+?)\$\$/,
     SUBMATCHES = /\$\$([\w.-_]+?)\$\$/g,
     DEFAULT_LOOKUP = [DEFAULT];
-
+var cloneDeep = require('./lib/cloneDeep');
+var mergeDeep = require('./lib/mergeDeep');
+var isA = require('./lib/isA');
+var isIterable = require('./lib/isIterable');
 
 //---------------------------------------------------------------
 // UTILITY FUNCTIONS
 
-function isA(item, constructor) {
-    return item && (item.constructor === constructor);
-}
-
-function isIterable(item) {
-    return isA(item, Object) || isA(item, Array);
-}
-
-function objectMerge(from, to) {
-    var key;
-    for (key in from) {
-        if (from.hasOwnProperty(key)) {
-            if (to.hasOwnProperty(key)) {
-                // Property in destination object set; update its value.
-                if (isA(from[key], Object)) {
-                    to[key] = objectMerge(from[key], to[key]);
-                } else {
-                    to[key] = from[key];
-                }
-            } else {
-                // Property in destination object not set; create it and set its value.
-                to[key] = from[key];
-            }
-        }
-    }
-    return to;
-}
 
 function extract(bag, key, def) {
     var keys,
@@ -87,7 +63,7 @@ function Ycb(bundle, options) {
     this.schema = {};
     this.dimsUsed = {}; // dim name: value: true
     this._dimensionHierarchies = {};
-    this._processRawBundle(this._cloneObj(bundle), this.options);
+    this._processRawBundle(cloneDeep(bundle), this.options);
 }
 Ycb.prototype = {
 
@@ -98,7 +74,7 @@ Ycb.prototype = {
      * @return {object} the dimensions
      */
     getDimensions: function () {
-        return this._cloneObj(this.dimensions);
+        return cloneDeep(this.dimensions);
     },
 
 
@@ -119,7 +95,7 @@ Ycb.prototype = {
             if (this.settings.hasOwnProperty(path)) {
                 context = this._getContextFromLookupPath(path);
                 // clone, so that no-one mutates us
-                if (!callback(context, this._cloneObj(this.settings[path]))) {
+                if (!callback(context, cloneDeep(this.settings[path]))) {
                     break;
                 }
             }
@@ -140,7 +116,7 @@ Ycb.prototype = {
             config = {};
 
         context = context || {};
-        options = objectMerge(this.options, options || {});
+        options = mergeDeep(this.options, options || {});
 
         lookupPaths = this._getLookupPaths(context, options);
 
@@ -160,7 +136,7 @@ Ycb.prototype = {
                     console.log(JSON.stringify(this.settings[lookupPaths[path]], null, 4));
                 }
                 // merge a copy so that we don't modify the source
-                config = objectMerge(this._cloneObj(this.settings[lookupPaths[path]]), config);
+                config = mergeDeep(this.settings[lookupPaths[path]], config);
             }
         }
 
@@ -209,7 +185,7 @@ Ycb.prototype = {
                     console.log('----USING---- ' + lookupPaths[path]);
                     console.log(JSON.stringify(this.settings[lookupPaths[path]], null, 4));
                 }
-                config.push(this._cloneObj(this.settings[lookupPaths[path]]));
+                config.push(cloneDeep(this.settings[lookupPaths[path]]));
             }
         }
         return config;
@@ -419,7 +395,7 @@ Ycb.prototype = {
                             this.settings[key] ? (' onto ' + this.settings[key].__ycb_source__) : ''
                         ));
                     }
-                    objectMerge(section, this.settings[key]);
+                    mergeDeep(section, this.settings[key]);
                 }
             }
         }
@@ -614,41 +590,6 @@ Ycb.prototype = {
                 }
             }
         }
-    },
-
-
-    /**
-     * @private
-     * @method _cloneObj
-     * @param {object} o object to clone
-     * @return {object} a copy of the object
-     */
-    _cloneObj: function (o) {
-        var newO,
-            i;
-
-        if (typeof o !== 'object') {
-            return o;
-        }
-        if (!o) {
-            return o;
-        }
-
-        if ('[object Array]' === Object.prototype.toString.apply(o)) {
-            newO = [];
-            for (i = 0; i < o.length; i += 1) {
-                newO[i] = this._cloneObj(o[i]);
-            }
-            return newO;
-        }
-
-        newO = {};
-        for (i in o) {
-            if (o.hasOwnProperty(i)) {
-                newO[i] = this._cloneObj(o[i]);
-            }
-        }
-        return newO;
     }
 
 

--- a/lib/cloneDeep.js
+++ b/lib/cloneDeep.js
@@ -1,0 +1,27 @@
+module.exports = function cloneDeep(o) {
+    var newO,
+        i;
+
+    if (typeof o !== 'object') {
+        return o;
+    }
+    if (!o) {
+        return o;
+    }
+
+    if ('[object Array]' === Object.prototype.toString.apply(o)) {
+        newO = [];
+        for (i = 0; i < o.length; i += 1) {
+            newO[i] = cloneDeep(o[i]);
+        }
+        return newO;
+    }
+
+    newO = {};
+    for (i in o) {
+        if (o.hasOwnProperty(i)) {
+            newO[i] = cloneDeep(o[i]);
+        }
+    }
+    return newO;
+};

--- a/lib/isA.js
+++ b/lib/isA.js
@@ -1,0 +1,3 @@
+module.exports = function isA(item, constructor) {
+    return item && (item.constructor === constructor);
+};

--- a/lib/isIterable.js
+++ b/lib/isIterable.js
@@ -1,0 +1,5 @@
+var isA = require('./isA');
+
+module.exports = function isIterable(item) {
+    return isA(item, Object) || isA(item, Array);
+};

--- a/lib/mergeDeep.js
+++ b/lib/mergeDeep.js
@@ -1,0 +1,26 @@
+var isA = require('./isA');
+var cloneDeep = require('./cloneDeep');
+
+module.exports = function mergeDeep(from, to) {
+    var key;
+    for (key in from) {
+        if (from.hasOwnProperty(key)) {
+            // Property in destination object set; update its value.
+            if (isA(from[key], Object)) {
+                var mergeToObj;
+                if (to.hasOwnProperty(key) && isA(to[key], Object)) {
+                    mergeToObj = to[key];
+                } else {
+                    mergeToObj = {};
+                }
+                to[key] = mergeDeep(from[key], mergeToObj);
+            } else if (isA(from[key], Array)) {
+                to[key] = cloneDeep(from[key]);
+            } else {
+                // Other literals are copied
+                to[key] = from[key];
+            }
+        }
+    }
+    return to;
+};

--- a/package.json
+++ b/package.json
@@ -14,9 +14,10 @@
   "main": "index",
   "scripts": {
     "cover": "istanbul cover --dir artifacts -- _mocha tests/unit --recursive--reporter spec",
+    "dev": "mocha tests/unit --recursive --reporter spec -w",
     "lint": "eslint .",
     "pretest": "npm run lint",
-    "test": "mocha tests/unit --reporter spec"
+    "test": "mocha tests/unit --recursive --reporter spec"
   },
   "engines": {
     "node": ">0.4",

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -8,11 +8,11 @@
 
 var libpath = require('path');
 var libfs = require('fs');
-var libycb = require('../index');
+var libycb = require('../../index');
 var assert = require('assert');
 
 function readFixtureFile(file){
-    var path = libpath.join(__dirname, 'fixtures' , file);
+    var path = libpath.join(__dirname, '..', 'fixtures' , file);
     var data = libfs.readFileSync(path, 'utf8');
     return JSON.parse(data);
 }
@@ -263,8 +263,8 @@ describe('ycb unit tests', function () {
         });
 
         it('should substitute correctly against subs-expected', function () {
-            var config = require('./fixtures/substitutions.json'),
-                expected = require('./fixtures/subs-expected.json'),
+            var config = require('./../fixtures/substitutions.json'),
+                expected = require('./../fixtures/subs-expected.json'),
                 ycb;
 
             ycb = new libycb.Ycb([]);
@@ -606,38 +606,6 @@ describe('ycb unit tests', function () {
             assert(ctxs[JSON.stringify({region:'ca',flavor:'att'})]);
             assert(ctxs[JSON.stringify({region:'gb',flavor:'bt'})]);
             assert(ctxs[JSON.stringify({region:'fr',flavor:'bt'})]);
-        });
-    });
-
-    describe('_cloneObj', function () {
-        it('should deeply clone the full object', function () {
-            var bundle, ycb;
-            bundle = readFixtureFile('dimensions.json')
-                .concat(readFixtureFile('simple-1.json'));
-            ycb = new libycb.Ycb(bundle);
-
-            var obj, copy;
-            obj = {
-                inner: {
-                    string: 'value',
-                    number: 1,
-                    fn: function() {}
-                },
-                list: ['a', 'b', 'c']
-            };
-            copy = ycb._cloneObj(obj);
-
-            assert.notEqual(obj, copy);
-
-            assert.notEqual(obj.inner, copy.inner);
-            assert.deepEqual(obj.inner, copy.inner);
-
-            assert.equal(obj.inner.string, copy.inner.string);
-            assert.equal(obj.inner.number, copy.inner.number);
-            assert.equal(obj.inner.fn, copy.inner.fn);
-
-            assert.notEqual(obj.list, copy.list);
-            assert.deepEqual(obj.list, copy.list);
         });
     });
 });

--- a/tests/unit/lib/cloneDeep.js
+++ b/tests/unit/lib/cloneDeep.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*globals describe,it*/
+
+var deepClone = require('../../../lib/cloneDeep');
+var assert = require('assert');
+
+
+describe('ycb unit tests', function () {
+    describe('cloneDeep', function () {
+        it('should deeply clone the full object', function () {
+            var obj, copy;
+            obj = {
+                inner: {
+                    string: 'value',
+                    number: 1,
+                    fn: function() {}
+                },
+                list: ['a', 'b', 'c']
+            };
+            copy = deepClone(obj);
+
+            assert.notEqual(obj, copy);
+
+            assert.notEqual(obj.inner, copy.inner);
+            assert.deepEqual(obj.inner, copy.inner);
+
+            assert.equal(obj.inner.string, copy.inner.string);
+            assert.equal(obj.inner.number, copy.inner.number);
+            assert.equal(obj.inner.fn, copy.inner.fn);
+
+            assert.notEqual(obj.list, copy.list);
+            assert.deepEqual(obj.list, copy.list);
+        });
+    });
+});

--- a/tests/unit/lib/mergeDeep.js
+++ b/tests/unit/lib/mergeDeep.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2011-2013, Yahoo! Inc.  All rights reserved.
+ * Copyrights licensed under the New BSD License.
+ * See the accompanying LICENSE file for terms.
+ */
+
+/*globals describe,it*/
+
+var deepMerge = require('../../../lib/mergeDeep');
+var assert = require('assert');
+
+
+describe('ycb unit tests', function () {
+    describe('mergeDeep', function () {
+        it('should deeply merge the full object without referencing from object', function () {
+            var obj, copy;
+            obj = {
+                inner: {
+                    string: 'value',
+                    number: 1,
+                    fn: function() {}
+                },
+                list: ['a', 'b', 'c'],
+                string: 'string'
+            };
+            copy = deepMerge(obj, {});
+
+            assert.deepEqual(obj, copy);
+            assert.notEqual(obj, copy);
+            assert.notEqual(obj.inner, copy.inner);
+            assert.notEqual(obj.list, copy.list);
+        });
+
+        it('should deeply merge the full object without referencing from object', function () {
+            var obj, copy, fn = function () {};
+            obj = {
+                inner: {
+                    obj: {},
+                    string: 'value',
+                    number: 1,
+                    fn: fn
+                },
+                list: ['a', 'b', 'c'],
+                string: 'string'
+            };
+
+            var start = {
+                inner: {
+                    obj: {
+                        foo: 'bar'
+                    },
+                    string: 'bar'
+                },
+                list: ['a', 'b', 'c', 'd']
+            };
+            copy = deepMerge(obj, start);
+
+            var expected = {
+                inner: {
+                    obj: {
+                        foo: 'bar'
+                    },
+                    string: 'value',
+                    number: 1,
+                    fn: fn
+                },
+                list: ['a', 'b', 'c'],
+                string: 'string'
+            };
+            assert.deepEqual(expected, copy);
+            assert.notEqual(obj, copy);
+            assert.notEqual(obj.inner, copy.inner);
+            assert.notEqual(obj.inner.obj, copy.inner.obj);
+            assert.notEqual(obj.list, copy.list);
+        });
+    });
+});


### PR DESCRIPTION
Change merge to ensure new object does not reference old object so that clone does not need to be called as much during read.

```
+---------------------------------------+-----------------+-----------------+
|                                       │ YCB             │ New             |
+---------------------------------------+-----------------+-----------------+
| Base                                  │ 156,017 ops/sec │ 225,027 ops/sec |
+---------------------------------------+-----------------+-----------------+
| y20 (large config / large dimensions) │ 14,017 ops/sec  │ 16,776 ops/sec  |
+---------------------------------------+-----------------+-----------------+
| y20 (large config / small dimensions) │ 16,695 ops/sec  │ 19,972 ops/sec  |
+---------------------------------------+-----------------+-----------------+
| y20 (small config / large dimensions) │ 59,729 ops/sec  │ 66,058 ops/sec  |
+---------------------------------------+-----------------+-----------------+
| y20 (small config / small dimensions) │ 113,577 ops/sec │ 127,480 ops/sec |
+---------------------------------------+-----------------+-----------------+
```

In doing this optimization, `mergeDeep` needed access to `cloneDeep` so it was moved outside of the class. In order to keep the unit tests and add new ones I moved `mergeDeep` and `cloneDeep` to their own files (along with the other shared utility functions).