### PR TITLE
Add support for multiple context values

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,17 @@ var isIterable = require('./lib/isIterable');
 //---------------------------------------------------------------
 // UTILITY FUNCTIONS
 
+function arrayReverseUnique(arr){
+    var u = {}, r = [];
+    for(var i = arr.length - 1; i >= 0; --i){
+        if(u.hasOwnProperty(arr[i])) {
+            continue;
+        }
+        r.unshift(arr[i]);
+        u[arr[i]] = true;
+    }
+    return r;
+}
 
 function extract(bag, key, def) {
     var keys,
@@ -532,10 +543,23 @@ Ycb.prototype = {
 
         for (pos = 0; pos < this._dimensionOrder.length; pos += 1) {
             name = this._dimensionOrder[pos];
-            if (options.useAllDimensions || (this.dimsUsed[name] && this.dimsUsed[name][context[name]])) {
-                chains[name] = this._dimensionHierarchies[name][context[name]] || DEFAULT_LOOKUP;
+            var value = context[name];
+            if (isA(value, Array)) {
+                var lookup = [];
+                value.forEach(function (val) {
+                    if (options.useAllDimensions || (this.dimsUsed[name] && this.dimsUsed[name][val])) {
+                        lookup = lookup.concat(this._dimensionHierarchies[name][val] || DEFAULT_LOOKUP);
+                    } else {
+                        lookup = lookup.concat(DEFAULT_LOOKUP);
+                    }
+                }, this);
+                chains[name] = arrayReverseUnique(lookup);
             } else {
-                chains[name] = DEFAULT_LOOKUP;
+                if (options.useAllDimensions || (this.dimsUsed[name] && this.dimsUsed[name][value])) {
+                    chains[name] = this._dimensionHierarchies[name][value] || DEFAULT_LOOKUP;
+                } else {
+                    chains[name] = DEFAULT_LOOKUP;
+                }
             }
         }
         return chains;

--- a/tests/fixtures/buckets.json
+++ b/tests/fixtures/buckets.json
@@ -1,0 +1,18 @@
+[
+    {
+        "settings": ["master"],
+        "enableFeatureA": false,
+        "enableFeatureB": false,
+        "__ycb_source__": "tests/fixtures/buckets.json"
+    },
+    {
+        "settings": ["bucket:101"],
+        "enableFeatureA": true,
+        "__ycb_source__": "tests/fixtures/buckets.json"
+    },
+    {
+        "settings": ["bucket:201"],
+        "enableFeatureB": true,
+        "__ycb_source__": "tests/fixtures/buckets.json"
+    }
+]

--- a/tests/fixtures/dimensions.json
+++ b/tests/fixtures/dimensions.json
@@ -52,7 +52,16 @@
                 "jurisdiction": {}
             },
             {
-                "bucket": {}
+                "bucket": {
+                    "1xx": {
+                        "101": null,
+                        "102": null
+                    },
+                    "2xx": {
+                        "201": null,
+                        "202": null
+                    }
+                }
             },
             {
                 "flavor": {


### PR DESCRIPTION
This adds the ability for context values to be an array where merge precedence is in index order. While using multiple values will impact performance (less than adding a new dimension) this implementation ensures that using string values will continue to have the same performance characteristics.

|      | Single         | 2 Values         | 3 Values         |
|---|---|---|----|
| Base | 40,924 ops/sec | *invalid* | *invalid* |
| New  | 40,247 ops/sec | 32,181 ops/sec | 29,697 ops/sec |