### PR TITLE
[resolves #44] Add ability to have multiple dimension value in single settings declaration

### DIFF
--- a/tests/fixtures/dimensions.json
+++ b/tests/fixtures/dimensions.json
@@ -35,6 +35,9 @@
                         "fr_FR": {
                             "fr_CA": null
                         }
+                    },
+                    "es": {
+                        "es_ES": null
                     }
                 }
             },

--- a/tests/fixtures/simple-4.json
+++ b/tests/fixtures/simple-4.json
@@ -10,7 +10,7 @@
         "__ycb_source__": "tests/fixtures/simple-4.json"
     },
     {
-        "settings": ["lang:fr"],
+        "settings": ["lang:fr,es"],
         "foo": 1,
         "bar": 2,
         "baz": 3,

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -121,19 +121,32 @@ describe('ycb unit tests', function () {
         });
     });
 
-    describe('_getLookupPath', function () {
+    describe('_createSettingsLookups', function () {
         it('should generate the look up path for the section', function () {
             var dims = readFixtureFile('dimensions.json'),
-                ycb = new libycb.Ycb(dims),
-                context, path;
-            context = {
-                'region': 'ir',
-                'environment': 'preproduction',
-                'lang': 'fr_FR'
-            };
-            path = ycb._getLookupPath(context, {useAllDimensions: true});
+                ycb = new libycb.Ycb(dims);
+            var section1 = { section: 1 };
+            var section2 = { section: 2 };
+            var section3 = { section: 3};
+            var dimsUsed = {};
 
-            assert.equal('preproduction/*/*/*/*/*/fr_FR/ir/*/*/*', path);
+            ycb._createSettingsLookups(['region:fr'], section1, dimsUsed);
+            assert.equal(ycb.settings['*/*/*/*/*/*/*/fr/*/*/*'], section1);
+            assert(-1 !== dimsUsed.region.fr);
+
+            ycb._createSettingsLookups(['region:gb,ir'], section2, dimsUsed);
+            assert.equal(ycb.settings['*/*/*/*/*/*/*/gb/*/*/*'], section2);
+            assert(-1 !== dimsUsed.region.gb);
+            assert.equal(ycb.settings['*/*/*/*/*/*/*/ir/*/*/*'], section2);
+            assert(-1 !== dimsUsed.region.ir);
+
+            ycb._createSettingsLookups(['region:gb,ir', 'lang:en'], section3, dimsUsed);
+            assert.equal(ycb.settings['*/*/*/*/*/*/*/gb/*/*/*'], section2); // Not modified
+            assert.equal(ycb.settings['*/*/*/*/*/*/*/ir/*/*/*'], section2); // Not modified
+            assert.equal(ycb.settings['*/*/*/*/*/*/en/gb/*/*/*'], section3);
+            assert.equal(ycb.settings['*/*/*/*/*/*/en/ir/*/*/*'], section3);
+            assert(-1 !== dimsUsed.lang.en);
+
         });
     });
 
@@ -486,6 +499,30 @@ describe('ycb unit tests', function () {
             ycb = new libycb.Ycb(bundle);
             var config = ycb.read({
                 'lang': 'fr'
+            });
+            assert.deepEqual({
+                foo: 1,
+                bar: 2,
+                baz: 3,
+                oof: null,
+                rab: 0,
+                zab: false
+            }, config);
+
+            config = ycb.read({
+                'lang': 'es'
+            });
+            assert.deepEqual({
+                foo: 1,
+                bar: 2,
+                baz: 3,
+                oof: null,
+                rab: 0,
+                zab: false
+            }, config);
+
+            config = ycb.read({
+                'lang': ['es', 'fr']
             });
             assert.deepEqual({
                 foo: 1,


### PR DESCRIPTION
See #44 for feature request.

This only expands on the instantiation cost of YCB and does not affect `read`. 

`_getLookupPath` now needs to expand multiple settings to multiple lookup keys, so it was easier to reuse part of the `_getLookupPaths` method and pass it an explicit list of values to expand into lookup keys. By doing this, I was actually able to implement this with a net negative lines of code (except for tests).