### PR TITLE
fix the case when multi-value dimension is ab empty array

### DIFF
--- a/index.js
+++ b/index.js
@@ -517,14 +517,18 @@ Ycb.prototype = {
             var value = context[name];
             if (isA(value, Array)) {
                 var lookup = [];
-                value.forEach(function (val) {
-                    if (options.useAllDimensions || (this.dimsUsed[name] && this.dimsUsed[name][val])) {
-                        lookup = lookup.concat(this._dimensionHierarchies[name][val] || DEFAULT_LOOKUP);
-                    } else {
-                        lookup = lookup.concat(DEFAULT_LOOKUP);
-                    }
-                }, this);
-                chains[name] = arrayReverseUnique(lookup);
+                if (value.length > 0) {
+                    value.forEach(function (val) {
+                        if (options.useAllDimensions || (this.dimsUsed[name] && this.dimsUsed[name][val])) {
+                            lookup = lookup.concat(this._dimensionHierarchies[name][val] || DEFAULT_LOOKUP);
+                        } else {
+                            lookup = lookup.concat(DEFAULT_LOOKUP);
+                        }
+                    }, this);
+                    chains[name] = arrayReverseUnique(lookup);
+                } else {
+                    chains[name] = DEFAULT_LOOKUP;
+                }
             } else {
                 if (options.useAllDimensions || (this.dimsUsed[name] && this.dimsUsed[name][value])) {
                     chains[name] = this._dimensionHierarchies[name][value] || DEFAULT_LOOKUP;

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -119,6 +119,18 @@ describe('ycb unit tests', function () {
                 '*'
             ], list.bucket);
         });
+        it('should generate default lookup when multi-value dimensions is an empty array', function () {
+            var dims = readFixtureFile('dimensions.json'),
+                ycb = new libycb.Ycb(dims),
+                context, list;
+            context = {
+                'bucket': []
+            };
+            list = ycb._makeOrderedLookupList(context, {useAllDimensions: true});
+            assert.deepEqual([
+                '*'
+            ], list.bucket);
+        });
     });
 
     describe('_createSettingsLookups', function () {
@@ -241,6 +253,20 @@ describe('ycb unit tests', function () {
                 '*/*/*/*/*/*/*/*/*/201/*',
                 '*/*/*/*/*/*/*/*/*/1xx/*',
                 '*/*/*/*/*/*/*/*/*/101/*'
+            ];
+            assert.deepEqual(expected, paths);
+        });
+        it('should handle multi-value dimensions with an empty array', function () {
+            var dims = readFixtureFile('dimensions.json'),
+                ycb = new libycb.Ycb(dims),
+                context, paths, expected;
+            context = {
+                'bucket': []
+            };
+            paths = ycb._getLookupPaths(context, {useAllDimensions: true});
+
+            expected = [
+                '*/*/*/*/*/*/*/*/*/*/*'
             ];
             assert.deepEqual(expected, paths);
         });


### PR DESCRIPTION
@drewfish  @redonkulus @mridgway 

if the context is an array, but that's empty, we won't run [this logic](https://github.com/yahoo/ycb/blob/master/index.js#L521-L525), and `_makeOrderedLookupList ` returns an empty array for that dimension, eventually we will generate wrong lookup list like `*/*/*/*/*/*/*/*/*//*` 

update the logic, when it's an empty array, assign default lookup directly

