### PR TITLE
Use Tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,15 @@ function replacer(base) {
     };
 }
 
+function omit(obj, omitKey) {
+    return Object.keys(obj).reduce((result, key) => {
+        if(key !== omitKey) {
+            result[key] = obj[key];
+        }
+        return result;
+    }, {});
+}
+
 //---------------------------------------------------------------
 // OBJECT ORIENTED INTERFACE
 
@@ -67,51 +76,17 @@ function replacer(base) {
  */
 function Ycb(bundle, options) {
     this.options = options || {};
-    this.dimensions = {};
-    this._dimensionOrder = [];
-    this.settings = {};
-    this.schema = {};
-    this.dimsUsed = {}; // dim name: value: true
-    this._dimensionHierarchies = {};
+    this.dimensionsList = [];
+    this.dimensionsToIndex = {};
+    this.valueToNumber = {};
+    this.numberToValue = ['*'];
+    this.precedenceMap = [[0]];
+    this.tree = {};
+    this.masterDelta = undefined;
+    this.dimensions = [];
     this._processRawBundle(cloneDeep(bundle), this.options);
 }
 Ycb.prototype = {
-
-
-    /**
-     * Returns the dimensions in the YCB file.
-     * @method getDimensions
-     * @return {object} the dimensions
-     */
-    getDimensions: function () {
-        return cloneDeep(this.dimensions);
-    },
-
-
-    /**
-     * Iterates over all the setting sections in the YCB file, calling the
-     * callback for each section.
-     * @method walkSettings
-     * @param callback {function(settings, config)}
-     * @param callback.settings {object} the condition under which section will be used
-     * @param callback.config {object} the configuration in the section
-     * @param callback.return {boolean} if the callback returns false, then walking is stopped
-     * @return {nothing} results returned via callback
-     */
-    walkSettings: function (callback) {
-        var path,
-            context;
-        for (path in this.settings) {
-            if (this.settings.hasOwnProperty(path)) {
-                context = this._getContextFromLookupPath(path);
-                // clone, so that no-one mutates us
-                if (!callback(context, cloneDeep(this.settings[path]))) {
-                    break;
-                }
-            }
-        }
-    },
-
 
     /**
      * Read the file.
@@ -120,87 +95,469 @@ Ycb.prototype = {
      * @param options {object}
      * @return {object}
      */
-    read: function (context, options) {
-        var lookupPaths,
-            path,
-            config = {};
-
-        context = context || {};
-        options = mergeDeep(this.options, options || {}, true);
-
-        lookupPaths = this._getLookupPaths(context, options);
-
-        if (options.debug) {
-            console.log(JSON.stringify(context, null, 4));
-            console.log(JSON.stringify(this.dimensions, null, 4));
-            console.log(JSON.stringify(this.settings, null, 4));
-            console.log(JSON.stringify(this.schema, null, 4));
-            console.log(JSON.stringify(lookupPaths, null, 4));
+    read: function(contextObj, options) {
+        options = options ? mergeDeep(this.options, options, true) : this.options;
+        let context = this._parseContext(contextObj);
+        let subKey = options.applySubstitutions !== false ? 'subbed': 'unsubbed';
+        let collector;
+        collector = this.masterDelta ? cloneDeep(this.masterDelta[subKey]) : {};
+        this._readHelper(this.tree, 0, context, collector, subKey);
+        if(collector['__ycb_source__']) {
+            return omit(collector, '__ycb_source__');
         }
-
-        // Now we simply merge each matching settings section we find into the config
-        for (path = 0; path < lookupPaths.length; path += 1) {
-            if (this.settings[lookupPaths[path]]) {
-                if (options.debug) {
-                    console.log('----USING---- ' + lookupPaths[path]);
-                    console.log(JSON.stringify(this.settings[lookupPaths[path]], null, 4));
-                }
-                // merge a copy so that we don't modify the source
-                config = mergeDeep(this.settings[lookupPaths[path]], config);
-            }
-        }
-
-        if (options.applySubstitutions !== false) {
-            this._applySubstitutions(config);
-        }
-
-        if (options.validate) {
-            console.log('The YCB option "validate" is not implemented yet.');
-        }
-        delete config.__ycb_source__;
-        return config;
+        return collector;
     },
-
 
     /**
-     * Like read(), but doesn't merge the found sections.
-     * Also, doesn't do substitutions.
-     *
-     * @method readNoMerge
-     * @param context {object}
-     * @param options {object}
-     * @return {array of objects}
+     * Recurse through the tree merging configs that apply to the given context.
+     * @param cur {object} the current node.
+     * @param depth {int} current depth in tree.
+     * @param context {array} the context in internal format.
+     * @param collector {object} the config we merge onto.
+     * @param subKey {string} determines if substituted or non-substituted configs are used.
+     * @private
      */
-    readNoMerge: function (context, options) {
-        var lookupPaths,
-            path,
-            config = [];
-
-        context = context || {};
-
-        lookupPaths = this._getLookupPaths(context, options);
-
-        if (options.debug) {
-            console.log(JSON.stringify(context, null, 4));
-            console.log(JSON.stringify(this.dimensions, null, 4));
-            console.log(JSON.stringify(this.settings, null, 4));
-            console.log(JSON.stringify(this.schema, null, 4));
-            console.log(JSON.stringify(lookupPaths, null, 4));
+    _readHelper: function(cur, depth, context, collector, subKey) {
+        if(depth === context.length) {
+            mergeDeep(cur[subKey], collector);
+            return;
         }
-
-        // Now we simply merge each matching settings section we find into the config
-        for (path = 0; path < lookupPaths.length; path += 1) {
-            if (this.settings[lookupPaths[path]]) {
-                if (options.debug) {
-                    console.log('----USING---- ' + lookupPaths[path]);
-                    console.log(JSON.stringify(this.settings[lookupPaths[path]], null, 4));
-                }
-                config.push(cloneDeep(this.settings[lookupPaths[path]]));
+        let value = context[depth];
+        if(value.constructor !== Array) {
+            this._expand(cur, depth, context, collector, value, subKey);
+        } else {
+            let i = value.length;
+            while(i--) {
+                this._expand(cur, depth, context, collector, value[i], subKey);
             }
         }
-        return config;
     },
 
+    /**
+     * Recurse to all children that apply to the given context.
+     * @param cur
+     * @param depth
+     * @param context
+     * @param collector
+     * @param value
+     * @param subKey
+     * @private
+     */
+    _expand: function(cur, depth, context, collector, value, subKey) {
+        let keys = this.precedenceMap[value];
+        let n = keys.length;
+        for(let i=0; i<n; i++) {
+            if(cur[keys[i]] !== undefined) {
+                this._readHelper(cur[keys[i]], depth+1, context, collector, subKey);
+            }
+        }
+    },
+
+    /**
+     * Read the file.
+     * @method read
+     * @param context {object}
+     * @param options {object}
+     * @return {object}
+     */
+    readNoMerge: function(contextObj, options) {
+        let context = this._parseContext(contextObj);
+        let subKey = options.applySubstitutions !== false ? 'subbed': 'unsubbed';
+        let collector;
+        collector = this.masterDelta ? this.masterDelta : [];
+        this._readNoMergeHelper(this.tree, 0, context, collector, subKey);
+        return cloneDeep(collector);
+    },
+
+    /**
+     * Recurse through the tree collecting configs that apply to the given context.
+     * @param cur {object} the current node.
+     * @param depth {int} current depth in tree.
+     * @param context {array} the context in internal format.
+     * @param collector {object} the array we push configs to.
+     * @param subKey {string} determines if substituted or non-substituted configs are used.
+     * @private
+     */
+    _readNoMergeHelper: function(cur, depth, context, collector, subKey) {
+        if(depth === context.length) {
+            collector.push(cur[subKey]);
+            return;
+        }
+        let value = context[depth];
+        if(value.constructor !== Array) {
+            this._expandNoMerge(cur, depth, context, collector, value, subKey);
+        } else {
+            let i = value.length;
+            while(i--) {
+                this._expandNoMerge(cur, depth, context, collector, value, subKey);
+            }
+        }
+    },
+
+    /**
+     * Recurse to all children that apply to the given context.
+     * @param cur
+     * @param depth
+     * @param context
+     * @param collector
+     * @param value
+     * @param subKey
+     * @private
+     */
+    _expandNoMerge: function(cur, depth, context, collector, value, subKey) {
+        let keys = this.precedenceMap[value];
+        let n = keys.length;
+        for(let i=0; i<n; i++) {
+            if(cur[keys[i]] !== undefined) {
+                this._readNoMergeHelper(cur[keys[i]], depth+1, context, collector, subKey);
+            }
+        }
+    },
+
+    /**
+     * Converts a context object to equivalent array of numerical values.
+     *
+     * @param contextObj
+     * @returns {any[]}
+     * @private
+     */
+    _parseContext: function(contextObj) {
+        if(contextObj === undefined) {
+            contextObj = {};
+        }
+        let context = new Array(this.dimensionsList.length);
+        for(let i=0; i<this.dimensionsList.length; i++) {
+            let dimension = this.dimensionsList[i];
+            if(contextObj.hasOwnProperty(dimension)) {
+                let value = contextObj[dimension];
+                if(value.constructor === Array) {
+                    let newValue = [];
+                    for(let j=0; j<value.length; j++) {
+                        let numValue = this.valueToNumber[dimension][value[j]];
+                        if(numValue !== undefined) {
+                            newValue.push(numValue);
+                        }
+                    }
+                    if(newValue.length) {
+                        context[i] = newValue;
+                        continue;
+                    }
+                } else {
+                    let numValue = this.valueToNumber[dimension][value];
+                    if(numValue !== undefined) {
+                        context[i] = numValue;
+                        continue;
+                    }
+                }
+            }
+            context[i] = 0;
+        }
+        return context;
+    },
+
+    /**
+     * Convert internal num array context to context object.
+     * @param context
+     * @private
+     */
+    _contextToObject: function(context) {
+        let contextObj = {};
+        for(let i=0; i<context.length; i++) {
+            if(context[i] !== '0') {
+                contextObj[this.dimensionsList[i]] = this.numberToValue[context[i]];
+            }
+        }
+        return contextObj;
+    },
+
+    /**
+     * @private
+     * @method _processRawBundle
+     * @param bundle {object}
+     * @param options {object}
+     * @return {nothing}
+     */
+    _processRawBundle: function(config, options) {
+        let dimCheckResult = this._checkDimensions(config);
+        let dimensionsObject = dimCheckResult[0];
+        let totalDimensions = dimCheckResult[1];
+
+        let settingsCheckResult = this._checkSettings(config, totalDimensions, dimensionsObject.length);
+        let usedDimensions = settingsCheckResult[0];
+        let usedValues = settingsCheckResult[1];
+        let contexts = settingsCheckResult[2];
+
+        let activeDimensions = this._parseDimensions(dimensionsObject, usedDimensions, usedValues);
+
+        for(let configIndex=0; configIndex<config.length; configIndex++) {
+            let fullContext = contexts[configIndex];
+            if(fullContext !== undefined) {
+                let context = this._filterContext(fullContext, activeDimensions, usedValues, config[configIndex].settings);
+                if(context !== undefined) {
+                    this._buildTreeHelper(this.tree, 0, context, this._buildDelta(config[configIndex]));
+                }
+            }
+        }
+    },
+
+    /**
+     * Extract dimensions object and dimension -> number map
+     * @param config
+     * @returns {*[]}
+     * @private
+     */
+    _checkDimensions: function(config) {
+        for(let i=0; i<config.length; i++) {
+            if(config[i].dimensions) {
+                let dimensions = config[i].dimensions;
+                this.dimensions = dimensions;
+                let allDimensions = {};
+                for(let j=0; j<dimensions.length; j++) {
+                    let name
+                    for(name in dimensions[j]) {
+                        allDimensions[name] = j;
+                        break;
+                    }
+                }
+                return [dimensions, allDimensions];
+            }
+        }
+        return [[], {}];
+    },
+
+    /**
+     * Evaluate settings and determine which dimensions and values are used. Check for unknown dimensions.
+     * Set the master config if it exist.
+     * @param config
+     * @param allDimensions
+     * @param height
+     * @returns {*[]}
+     * @private
+     */
+    _checkSettings: function(config, allDimensions, height) {
+        let usedDimensions = {};
+        let usedValues = {};
+        let contexts = {};
+        configLoop:
+            for(let i=0; i<config.length; i++) {
+                if (config[i].settings) {
+                    let setting = config[i].settings;
+                    if(setting.length === 0 ) {
+                        continue;
+                    }
+                    if(setting[0] === 'master') {
+                        if(this.masterDelta !== undefined) {
+                            this.masterDelta = mergeDeep(this._buildDelta(config[i]), this.masterDelta, true);
+                        } else {
+                            this.masterDelta = this._buildDelta(config[i]);
+                        }
+                        continue;
+                    }
+                    let context = new Array(height);
+                    for(let q=0; q<height; q++) {
+                        context[q] = '*';
+                    }
+                    for(let j=0; j<setting.length; j++) {
+                        let kv = setting[j].split(':');
+                        let dim = kv[0];
+                        let index = allDimensions[dim];
+                        if(index === undefined) {
+                            console.log('WARNING: invalid dimension "' + dim +
+                                '" in settings ' + JSON.stringify(setting));
+                            continue configLoop;
+                        }
+                        usedDimensions[dim] = 1;
+                        usedValues[dim] = usedValues[dim] || {};
+
+                        if(kv[1].indexOf(',') === -1) {
+                            usedValues[dim][kv[1]] = 1;
+                            context[index] = kv[1];
+                        } else {
+                            let vals = kv[1].split(',');
+                            context[index] = vals;
+                            for(let k=0; k<vals.length; k++) {
+                                usedValues[dim][vals[k]] = 1;
+                            }
+                        }
+                    }
+                    contexts[i] = context;
+                }
+            }
+        return [usedDimensions, usedValues, contexts];
+    },
+
+    /**
+     * Convert config to delta.
+     * @param config
+     * @returns {{subbed: object, unsubbed: object}}
+     * @private
+     */
+    _buildDelta: function(config) {
+        config = omit(config, 'settings');
+        let subbed = cloneDeep(config);
+        let subFlag = this._applySubstitutions(subbed);
+        let unsubbed = subFlag ? config : subbed;
+        return {subbed:subbed, unsubbed:unsubbed};
+    },
+
+    /**
+     * Evaluate dimensions and omit unused dimensions.
+     * @param dimensions
+     * @param usedDimensions
+     * @param usedValues
+     * @returns {any[]}
+     * @private
+     */
+    _parseDimensions: function(dimensions, usedDimensions, usedValues) {
+        let activeDimensions = new Array(dimensions.length);
+        var valueCounter = 1;
+        for(let i=0; i<dimensions.length; i++) {
+            let dimensionName;
+            for(dimensionName in dimensions[i]){break}
+            if(usedDimensions[dimensionName] === undefined) {
+                activeDimensions[i] = 0;
+                continue;
+            }
+            activeDimensions[i] = 1;
+            this.dimensionsList.push(dimensionName);
+            this.dimensionsToIndex[dimensionName] = i;
+            let labelCollector = {};
+            valueCounter = this._dimensionWalk(dimensions[i][dimensionName], usedValues[dimensionName],
+                valueCounter, [0], this.precedenceMap, labelCollector, this.numberToValue);
+            this.valueToNumber[dimensionName] = labelCollector;
+        }
+        return activeDimensions;
+    },
+
+    /**
+     * Traverse a dimension hierarchy, label dimension values, and fill the precedence map and dim <-> num maps.
+     * Mark used dimension values.
+     * @param dimension
+     * @param used
+     * @param label
+     * @param path
+     * @param pathCollector
+     * @param valueToNumCollector
+     * @param numToValueCollector
+     * @returns {*}
+     * @private
+     */
+    _dimensionWalk: function(dimension, used, label, path, pathCollector, valueToNumCollector, numToValueCollector) {
+        for(var key in dimension) {
+            let currentPath;
+            if(used[key]) {
+                used[key] = 2;
+                currentPath = path.concat(label);
+            } else {
+                currentPath = path;
+            }
+            if(currentPath.length > 1) {
+                pathCollector.push(currentPath);
+                numToValueCollector.push(key);
+                valueToNumCollector[key] = label++;
+            }
+            if(dimension[key] !== null) {
+                label = this._dimensionWalk(dimension[key], used, label, currentPath,
+                    pathCollector, valueToNumCollector, numToValueCollector);
+            }
+        }
+        return label;
+    },
+
+    /**
+     * Convert config context and omit invalid dimension values.
+     * @param fullContext
+     * @param activeDimensions
+     * @param usedValues
+     * @param setting
+     * @returns {any[]}
+     * @private
+     */
+    _filterContext: function(fullContext, activeDimensions, usedValues, setting) {
+        let height = this.dimensionsList.length;
+        let newContext = new Array(height);
+        for(let i=0; i<height; i++) {
+            newContext[i] = 0;
+        }
+        let activeIndex = 0;
+        for(let i=0; i<fullContext.length; i++) {
+            if(activeDimensions[i]) {
+                let dimensionName = this.dimensionsList[activeIndex];
+                let contextValue = fullContext[i];
+                if(contextValue.constructor === Array) {
+                    let newValue = [];
+                    for(let k=0; k<contextValue.length; k++) {
+                        let valueChunk = contextValue[k];
+                        if(usedValues[dimensionName][valueChunk] === 2) {
+                            newValue.push(this.valueToNumber[dimensionName][valueChunk]);
+                        } else {
+                            console.log('WARNING: invalid value "' + valueChunk + '" for dimension "' +
+                                this.dimensionsList[activeIndex] +
+                                '" in settings ' + JSON.stringify(setting));
+                        }
+                    }
+                    if(newValue.length === 0) {
+                        return;
+                    }
+                    newContext[activeIndex] = newValue;
+                } else {
+                    if(usedValues[dimensionName][contextValue] === 2) {
+                        newContext[activeIndex] = this.valueToNumber[dimensionName][contextValue];
+                    } else if(contextValue !== '*') {
+                        console.log('WARNING: invalid value "' + contextValue +
+                            '" in settings ' + JSON.stringify(setting));
+                        return;
+                    }
+                }
+                activeIndex++;
+            }
+        }
+        return newContext;
+    },
+
+    /**
+     * Insert the given context and delta into the tree.
+     * @param root
+     * @param depth
+     * @param context
+     * @param delta
+     * @private
+     */
+    _buildTreeHelper: function(root, depth, context, delta) {
+        let currentValue = context[depth];
+        let isMulti = currentValue.constructor === Array;
+        if(depth === context.length-1) {
+            if(isMulti) {
+                for(let i=0; i<currentValue.length; i++) {
+                    let curDelta = delta;
+                    if(root[currentValue[i]] !== undefined) {
+                        curDelta = mergeDeep(delta, root[currentValue[i]], true);
+                    }
+                    root[currentValue[i]] = curDelta;
+                }
+            } else {
+                let curDelta = delta;
+                if(root[currentValue] !== undefined) {
+                    curDelta = mergeDeep(delta, root[currentValue], true);
+                }
+                root[currentValue] = curDelta;
+            }
+            return;
+        }
+        if(isMulti){
+            for(let i=0; i<currentValue.length; i++) {
+                if(root[currentValue[i]] === undefined) {
+                    root[currentValue[i]] = {};
+                }
+                this._buildTreeHelper(root[currentValue[i]], depth+1, context, delta);
+            }
+        } else {
+            if(root[currentValue] === undefined) {
+                root[currentValue] = {};
+            }
+            this._buildTreeHelper(root[currentValue], depth+1, context, delta);
+        }
+    },
 
     /**
      * This is a first pass at hairball of a function.
@@ -217,9 +574,9 @@ Ycb.prototype = {
             sub,
             find,
             item;
-
         base = base || config;
         parent = parent || {ref: config, key: null};
+        let subFlag = false;
 
         for (key in config) {
             if (config.hasOwnProperty(key)) {
@@ -228,12 +585,13 @@ Ycb.prototype = {
                 if (isIterable(config[key])) {
                     // parent param {ref: config, key: key} is a recursion
                     // pointer that needed only when replacing "keys"
-                    this._applySubstitutions(config[key], base, {ref: config, key: key});
+                    subFlag = this._applySubstitutions(config[key], base, {ref: config, key: key}) || subFlag;
 
                 } else {
                     // Test if the key is a "substitution" key
                     sub = SUBMATCH.exec(key);
                     if (sub && (sub[0] === key)) {
+                        subFlag = true;
                         // Pull out the key to "find"
                         find = extract(base, sub[1], null);
 
@@ -258,6 +616,7 @@ Ycb.prototype = {
                         }
 
                     } else if (SUBMATCH.test(config[key])) {
+                        subFlag = true;
                         // Test if the value is a "substitution" value
                         // We have a match so lets use it
                         sub = SUBMATCH.exec(config[key]);
@@ -286,318 +645,59 @@ Ycb.prototype = {
                 }
             }
         }
-    },
-
-
-    /**
-     * @private
-     * @method _getLookupPaths
-     * @param context {object} Key/Value list
-     * @param options {object} runtime options
-     * @return {Array}
-     */
-    _getLookupPaths: function (context, options) {
-        var lookupList = this._makeOrderedLookupList(context, options);
-        return this._expandLookupList(lookupList, options);
+        return subFlag;
     },
 
     /**
-     * Expands a lookupList into a list of string keys
-     * @private
-     * @param lookupList {Object}
-     * @returns {[String]}
+     * Iterates over all the setting sections in the YCB file, calling the
+     * callback for each section.
+     * @method walkSettings
+     * @param callback {function(settings, config)}
+     * @param callback.settings {object} the condition under which section will be used
+     * @param callback.config {object} the configuration in the section
+     * @param callback.return {boolean} if the callback returns false, then walking is stopped
+     * @return {nothing} results returned via callback
      */
-    _expandLookupList: function (lookupList) {
-        var dimensions = Object.keys(lookupList),
-            pos,
-            current = dimensions.length - 1,
-            combination = [];
-
-        // This is our combination that we will tumble over
-        for (pos = 0; pos < dimensions.length; pos += 1) {
-            combination.push({
-                current: 0,
-                total: lookupList[dimensions[pos]].length - 1
-            });
+    walkSettings: function (callback) {
+        if(this.masterDelta && !callback({}, cloneDeep(this.masterDelta))) {
+            return undefined;
         }
+        this._walkSettingsHelper(this.tree, 0, [], callback, [false]);
+    },
 
-        function tumble(combination, location) {
-            // If the location is not found return
-            if (!combination[location]) {
-                return false;
-            }
-
-            // Move along to the next item
-            combination[location].current += 1;
-
-            // If the next item is not found move to the prev location
-            if (combination[location].current > combination[location].total) {
-                combination[location].current = 0;
-                return tumble(combination, location - 1);
-            }
-
+    /**
+     * Recursive helper for walking the config tree.
+     * @param cur
+     * @param depth
+     * @param context
+     * @param callback
+     * @param stop
+     * @returns {*}
+     * @private
+     */
+    _walkSettingsHelper: function(cur, depth, context, callback, stop) {
+        if(stop[0]) {
             return true;
         }
-
-        var paths = [];
-        do {
-            var path = [];
-            for (pos = 0; pos < dimensions.length; pos += 1) {
-                path.push(lookupList[dimensions[pos]][combination[pos].current]);
+        if(depth === this.dimensionsList.length) {
+            stop[0] = !callback(this._contextToObject(context), cloneDeep(cur));
+            return stop[0];
+        }
+        let key;
+        for(key in cur) {
+            if(this._walkSettingsHelper(cur[key], depth+1, context.concat(key), callback, stop)) {
+                return true;
             }
-            paths.push(path.join(SEPARATOR));
-        } while (tumble(combination, current));
-
-        return paths.reverse();
+        }
     },
 
     /**
-     * Creates a settings cache that maps a lookup key to the settings section
-     * @private
-     * @param settings {array} The list of dimensions and values the section applies to
-     * @param section {object} The configuration values for the settings
-     * @param dimsUsed {object}
-     * @param options {object}
-     * @return {void}
+     * Return clone of the dimensions object.
+     * @returns {array}
      */
-    _createSettingsLookups: function (settings, section, dimsUsed, options) {
-        var context = {};
-        for (var part = 0; part < settings.length; part += 1) {
-            var kv = settings[part].split(':');
-            var dim = kv[0];
-            var val = kv[1] ? kv[1].split(',') : kv[1];
-
-            if ('master' !== settings[0]) {
-                // Validate dimension name
-                if (!this._dimensionHierarchies.hasOwnProperty(dim)) {
-                    console.log('WARNING: invalid dimension "' + dim +
-                        '" in settings ' + JSON.stringify(settings));
-                    return;
-                }
-                dimsUsed[dim] = dimsUsed[dim] || [];
-                val.forEach(function (v) {
-                    // Validate dimension value
-                    if (!this._dimensionHierarchies[dim].hasOwnProperty(v)) {
-                        console.log('WARNING: invalid value "' + v + '" for dimension "' + dim +
-                            '" in settings ' + JSON.stringify(settings));
-                    } else {
-                        dimsUsed[dim].push(v);
-                    }
-                }, this);
-            }
-            context[dim] = val;
-        }
-
-        // Build the full context paths
-        var lookupList = {};
-        this._dimensionOrder.forEach(function (dim) {
-            lookupList[dim] = context[dim] || DEFAULT;
-        });
-        var keys = this._expandLookupList(lookupList, {
-            useAllDimensions: true
-        }, settings);
-
-        keys.forEach(function (key) {
-            // Add the section to the settings list with it's full key
-            if (!this.settings[key]) {
-                this.settings[key] = section;
-            } else {
-                if (options && options.debug) {
-                    console.log('Merging section ' + JSON.stringify(settings) + (
-                            section.__ycb_source__ ? (' from ' + section.__ycb_source__) : ''
-                        ) + (
-                            this.settings[key] ? (' onto ' + this.settings[key].__ycb_source__) : ''
-                        ));
-                }
-                // Clone original settings so that we don't override shared settings
-                this.settings[key] = mergeDeep(section, this.settings[key], true);
-            }
-        }, this);
-    },
-
-
-    /**
-     * @private
-     * @method _processRawBundle
-     * @param bundle {object}
-     * @param options {object}
-     * @return {nothing}
-     */
-    _processRawBundle: function (bundle, options) {
-        var pos,
-            section,
-            settings,
-            dimsUsed = {};
-
-        // Extract each section from the bundle
-        for (pos = 0; pos < bundle.length; pos += 1) {
-            section = bundle[pos];
-            if (section.dimensions) {
-                this.dimensions = section.dimensions;
-                this._calculateDimensionOrder();
-                this._calculateHierarchies();
-            } else if (section.schema) {
-                this.schema = section.schema;
-            } else if (section.settings) {
-                settings = section.settings;
-                // Remove the settings key now we are done with it
-                delete section.settings;
-                this._createSettingsLookups(settings, section, dimsUsed, options);
-            }
-        }
-
-        this._buildUsageMap(dimsUsed);
-    },
-
-    _buildUsageMap: function (dimsUsed) {
-        var i, j, k,
-            value,
-            name,
-            hierarchy;
-
-        // Assemble map of all dimensions used including ancestry
-        this.dimsUsed = {};
-        for (name in dimsUsed) {
-            if (dimsUsed.hasOwnProperty(name) && this._dimensionHierarchies.hasOwnProperty(name)) {
-                this.dimsUsed[name] = {};
-                for (i=0; i<dimsUsed[name].length; i += 1) {
-                    value = dimsUsed[name][i];
-                    for (hierarchy in this._dimensionHierarchies[name]) {
-                        if (this._dimensionHierarchies[name].hasOwnProperty(hierarchy)) {
-                            if (-1 !== this._dimensionHierarchies[name][hierarchy].indexOf(value)) {
-                                this.dimsUsed[name][hierarchy] = true;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    },
-
-
-    /**
-     * @private
-     * @method _getContextFromLookupPath
-     * @param path {string} the path
-     * @return {object} the corresponding context (really a partial context)
-     */
-    _getContextFromLookupPath: function (path) {
-        var parts = path.split(SEPARATOR),
-            p,
-            part,
-            dimName,
-            ctx = {};
-        for (p = 0; p < this._dimensionOrder.length; p += 1) {
-            part = parts[p];
-            if (DEFAULT !== part) {
-                // Having more than one key in the dimensions structure is against
-                // the YCB spec.
-                dimName = Object.keys(this.dimensions[p])[0];
-                ctx[dimName] = part;
-            }
-        }
-        return ctx;
-    },
-
-
-    /**
-     * @private
-     * @method _makeOrderedLookupList
-     * @param context {object} Key/Value list
-     * @param options {object}
-     * @return {object} list of lists
-     */
-    _makeOrderedLookupList: function (context, options) {
-        var pos,
-            name,
-            chains = {};
-
-        for (pos = 0; pos < this._dimensionOrder.length; pos += 1) {
-            name = this._dimensionOrder[pos];
-            var value = context[name];
-            if (isA(value, Array)) {
-                var lookup = [];
-                if (value.length > 0) {
-                    value.forEach(function (val) {
-                        if (options.useAllDimensions || (this.dimsUsed[name] && this.dimsUsed[name][val])) {
-                            lookup = lookup.concat(this._dimensionHierarchies[name][val] || DEFAULT_LOOKUP);
-                        } else {
-                            lookup = lookup.concat(DEFAULT_LOOKUP);
-                        }
-                    }, this);
-                    chains[name] = arrayReverseUnique(lookup);
-                } else {
-                    chains[name] = DEFAULT_LOOKUP;
-                }
-            } else {
-                if (options.useAllDimensions || (this.dimsUsed[name] && this.dimsUsed[name][value])) {
-                    chains[name] = this._dimensionHierarchies[name][value] || DEFAULT_LOOKUP;
-                } else {
-                    chains[name] = DEFAULT_LOOKUP;
-                }
-            }
-        }
-        return chains;
-    },
-
-    _calculateDimensionOrder: function () {
-        var pos, name;
-        for (pos = 0; pos < this.dimensions.length; pos += 1) {
-            for (name in this.dimensions[pos]) {
-                if (this.dimensions[pos].hasOwnProperty(name)) {
-                    this._dimensionOrder.push(name);
-                }
-            }
-        }
-    },
-
-
-    /**
-     * @private
-     * @method _calculateHierarchy
-     * @param parents {array}
-     * @param dimension {object} A single YCB dimension structured object
-     * @param build {string}
-     * @return {object} k/v map
-     */
-    _calculateHierarchy: function (parents, dimension, build) {
-        var key,
-            newParents,
-            nextDimension;
-
-        build = build || {};
-        if (typeof dimension === 'object') {
-            for (key in dimension) {
-                if (dimension.hasOwnProperty(key)) {
-                    nextDimension = dimension[key];
-                    newParents = ([key].concat(parents));
-                    build[key] = newParents;
-                    if (typeof nextDimension === 'object') {
-                        this._calculateHierarchy(newParents, nextDimension, build);
-                    }
-                }
-            }
-        }
-        return build;
-    },
-
-
-    /**
-     * @private
-     * @method _calculateHierarchies
-     * @return {nothing}
-     */
-    _calculateHierarchies: function () {
-        var pos,
-            name;
-
-        for (pos = 0; pos < this._dimensionOrder.length; pos += 1) {
-            name = this._dimensionOrder[pos];
-            this._dimensionHierarchies[name] = this._calculateHierarchy(DEFAULT_LOOKUP, this.dimensions[pos][name]);
-        }
+    getDimensions: function() {
+        return cloneDeep(this.dimensions);
     }
-
-
 };
 
 
@@ -611,7 +711,6 @@ module.exports = {
 
     // object-oriented interface
     Ycb: Ycb,
-
 
     /*
      * Processes an Object representing a YCB 2.0 Bundle as defined in the spec.
@@ -632,7 +731,6 @@ module.exports = {
         return ycb.read(context, opts);
     },
 
-
     /*
      * Like read(), but doesn't merge the found sections.
      *
@@ -648,6 +746,4 @@ module.exports = {
             opts = { debug: debug };
         return ycb.readNoMerge(context, opts);
     }
-
-
 };

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function replacer(base) {
 }
 
 function omit(obj, omitKey) {
-    return Object.keys(obj).reduce((result, key) => {
+    return Object.keys(obj).reduce(function(result, key) {
         if(key !== omitKey) {
             result[key] = obj[key];
         }
@@ -84,12 +84,12 @@ Ycb.prototype = {
      */
     read: function(contextObj, options) {
         options = options ? mergeDeep(this.options, options, true) : this.options;
-        let context = this._parseContext(contextObj);
-        let subKey = options.applySubstitutions !== false ? 'subbed': 'unsubbed';
-        let collector;
+        var context = this._parseContext(contextObj);
+        var subKey = options.applySubstitutions !== false ? 'subbed': 'unsubbed';
+        var collector;
         collector = this.masterDelta ? cloneDeep(this.masterDelta[subKey]) : {};
         this._readHelper(this.tree, 0, context, collector, subKey);
-        if(collector['__ycb_source__']) {
+        if(collector.__ycb_source__) {
             return omit(collector, '__ycb_source__');
         }
         return collector;
@@ -109,11 +109,11 @@ Ycb.prototype = {
             mergeDeep(cur[subKey], collector);
             return;
         }
-        let value = context[depth];
+        var value = context[depth];
         if(value.constructor !== Array) {
             this._expand(cur, depth, context, collector, value, subKey);
         } else {
-            let i = value.length;
+            var i = value.length;
             while(i--) {
                 this._expand(cur, depth, context, collector, value[i], subKey);
             }
@@ -122,18 +122,18 @@ Ycb.prototype = {
 
     /**
      * Recurse to all children that apply to the given context.
-     * @param cur
-     * @param depth
-     * @param context
-     * @param collector
-     * @param value
-     * @param subKey
+     * @param cur {object}
+     * @param depth {number}
+     * @param context {array}
+     * @param collector {object}
+     * @param value {number}
+     * @param subKey {string}
      * @private
      */
     _expand: function(cur, depth, context, collector, value, subKey) {
-        let keys = this.precedenceMap[value];
-        let n = keys.length;
-        for(let i=0; i<n; i++) {
+        var keys = this.precedenceMap[value];
+        var n = keys.length;
+        for(var i=0; i<n; i++) {
             if(cur[keys[i]] !== undefined) {
                 this._readHelper(cur[keys[i]], depth+1, context, collector, subKey);
             }
@@ -141,16 +141,16 @@ Ycb.prototype = {
     },
 
     /**
-     * Read the file.
+     * Read the configs for the given context and return them in order general to specific.
      * @method read
      * @param contextObj {object}
      * @param options {object}
-     * @return {object}
+     * @return {array}
      */
     readNoMerge: function(contextObj, options) {
-        let context = this._parseContext(contextObj);
-        let subKey = options.applySubstitutions !== false ? 'subbed': 'unsubbed';
-        let collector = this.masterDelta ? [this.masterDelta] : [];
+        var context = this._parseContext(contextObj);
+        var subKey = options.applySubstitutions !== false ? 'subbed': 'unsubbed';
+        var collector = this.masterDelta ? [this.masterDelta] : [];
         this._readNoMergeHelper(this.tree, 0, context, collector, subKey);
         return cloneDeep(collector);
     },
@@ -158,9 +158,9 @@ Ycb.prototype = {
     /**
      * Recurse through the tree collecting configs that apply to the given context.
      * @param cur {object} the current node.
-     * @param depth {int} current depth in tree.
+     * @param depth {number} current depth in tree.
      * @param context {array} the context in internal format.
-     * @param collector {object} the array we push configs to.
+     * @param collector {array} the array we push configs to.
      * @param subKey {string} determines if substituted or non-substituted configs are used.
      * @private
      */
@@ -169,11 +169,11 @@ Ycb.prototype = {
             collector.push(cur[subKey]);
             return;
         }
-        let value = context[depth];
+        var value = context[depth];
         if(value.constructor !== Array) {
             this._expandNoMerge(cur, depth, context, collector, value, subKey);
         } else {
-            let i = value.length;
+            var i = value.length;
             while(i--) {
                 this._expandNoMerge(cur, depth, context, collector, value, subKey);
             }
@@ -182,18 +182,18 @@ Ycb.prototype = {
 
     /**
      * Recurse to all children that apply to the given context.
-     * @param cur
-     * @param depth
-     * @param context
-     * @param collector
-     * @param value
-     * @param subKey
+     * @param cur {object}
+     * @param depth {number}
+     * @param context {array}
+     * @param collector {array}
+     * @param value {number}
+     * @param subKey {string}
      * @private
      */
     _expandNoMerge: function(cur, depth, context, collector, value, subKey) {
-        let keys = this.precedenceMap[value];
-        let n = keys.length;
-        for(let i=0; i<n; i++) {
+        var keys = this.precedenceMap[value];
+        var n = keys.length;
+        for(var i=0; i<n; i++) {
             if(cur[keys[i]] !== undefined) {
                 this._readNoMergeHelper(cur[keys[i]], depth+1, context, collector, subKey);
             }
@@ -203,23 +203,23 @@ Ycb.prototype = {
     /**
      * Converts a context object to equivalent array of numerical values.
      *
-     * @param contextObj
-     * @returns {int[]}
+     * @param contextObj {object}
+     * @returns {array}
      * @private
      */
     _parseContext: function(contextObj) {
         if(contextObj === undefined) {
             contextObj = {};
         }
-        let context = new Array(this.dimensionsList.length);
-        for(let i=0; i<this.dimensionsList.length; i++) {
-            let dimension = this.dimensionsList[i];
+        var context = new Array(this.dimensionsList.length);
+        for(var i=0; i<this.dimensionsList.length; i++) {
+            var dimension = this.dimensionsList[i];
             if(contextObj.hasOwnProperty(dimension)) {
-                let value = contextObj[dimension];
+                var value = contextObj[dimension];
                 if(value.constructor === Array) {
-                    let newValue = [];
-                    for(let j=0; j<value.length; j++) {
-                        let numValue = this.valueToNumber[dimension][value[j]];
+                    var newValue = [];
+                    for(var j=0; j<value.length; j++) {
+                        var numValue = this.valueToNumber[dimension][value[j]];
                         if(numValue !== undefined) {
                             newValue.push(numValue);
                         }
@@ -229,7 +229,7 @@ Ycb.prototype = {
                         continue;
                     }
                 } else {
-                    let numValue = this.valueToNumber[dimension][value];
+                    numValue = this.valueToNumber[dimension][value];
                     if(numValue !== undefined) {
                         context[i] = numValue;
                         continue;
@@ -243,12 +243,13 @@ Ycb.prototype = {
 
     /**
      * Convert internal num array context to context object.
-     * @param context
+     * @param context {array}
+     * @returns {object}
      * @private
      */
     _contextToObject: function(context) {
-        let contextObj = {};
-        for(let i=0; i<context.length; i++) {
+        var contextObj = {};
+        for(var i=0; i<context.length; i++) {
             if(context[i] !== '0') {
                 contextObj[this.dimensionsList[i]] = this.numberToValue[context[i]];
             }
@@ -260,24 +261,23 @@ Ycb.prototype = {
      * @private
      * @method _processRawBundle
      * @param config {object}
-     * @return
      */
     _processRawBundle: function(config) {
-        let dimCheckResult = this._checkDimensions(config);
-        let dimensionsObject = dimCheckResult[0];
-        let totalDimensions = dimCheckResult[1];
+        var dimCheckResult = this._checkDimensions(config);
+        var dimensionsObject = dimCheckResult[0];
+        var totalDimensions = dimCheckResult[1];
 
-        let settingsCheckResult = this._checkSettings(config, totalDimensions, dimensionsObject.length);
-        let usedDimensions = settingsCheckResult[0];
-        let usedValues = settingsCheckResult[1];
-        let contexts = settingsCheckResult[2];
+        var settingsCheckResult = this._checkSettings(config, totalDimensions, dimensionsObject.length);
+        var usedDimensions = settingsCheckResult[0];
+        var usedValues = settingsCheckResult[1];
+        var contexts = settingsCheckResult[2];
 
-        let activeDimensions = this._parseDimensions(dimensionsObject, usedDimensions, usedValues);
+        var activeDimensions = this._parseDimensions(dimensionsObject, usedDimensions, usedValues);
 
-        for(let configIndex=0; configIndex<config.length; configIndex++) {
-            let fullContext = contexts[configIndex];
+        for(var configIndex=0; configIndex<config.length; configIndex++) {
+            var fullContext = contexts[configIndex];
             if(fullContext !== undefined) {
-                let context = this._filterContext(fullContext, activeDimensions, usedValues, config[configIndex].settings);
+                var context = this._filterContext(fullContext, activeDimensions, usedValues, config[configIndex].settings);
                 if(context !== undefined) {
                     this._buildTreeHelper(this.tree, 0, context, this._buildDelta(config[configIndex]));
                 }
@@ -287,18 +287,18 @@ Ycb.prototype = {
 
     /**
      * Extract dimensions object and dimension -> number map
-     * @param config
-     * @returns {*[]}
+     * @param config {object}
+     * @returns {array}
      * @private
      */
     _checkDimensions: function(config) {
-        for(let i=0; i<config.length; i++) {
+        for(var i=0; i<config.length; i++) {
             if(config[i].dimensions) {
-                let dimensions = config[i].dimensions;
+                var dimensions = config[i].dimensions;
                 this.dimensions = dimensions;
-                let allDimensions = {};
-                for(let j=0; j<dimensions.length; j++) {
-                    let name;
+                var allDimensions = {};
+                for(var j=0; j<dimensions.length; j++) {
+                    var name;
                     for(name in dimensions[j]) {
                         allDimensions[name] = j;
                         break;
@@ -313,20 +313,20 @@ Ycb.prototype = {
     /**
      * Evaluate settings and determine which dimensions and values are used. Check for unknown dimensions.
      * Set the master config if it exist.
-     * @param config
-     * @param allDimensions
-     * @param height
-     * @returns {*[]}
+     * @param config {object}
+     * @param allDimensions {object}
+     * @param height {number}
+     * @returns {array}
      * @private
      */
     _checkSettings: function(config, allDimensions, height) {
-        let usedDimensions = {};
-        let usedValues = {};
-        let contexts = {};
+        var usedDimensions = {};
+        var usedValues = {};
+        var contexts = {};
         configLoop:
-            for(let i=0; i<config.length; i++) {
+            for(var i=0; i<config.length; i++) {
                 if (config[i].settings) {
-                    let setting = config[i].settings;
+                    var setting = config[i].settings;
                     if(setting.length === 0 ) {
                         continue;
                     }
@@ -338,14 +338,14 @@ Ycb.prototype = {
                         }
                         continue;
                     }
-                    let context = new Array(height);
-                    for(let q=0; q<height; q++) {
+                    var context = new Array(height);
+                    for(var q=0; q<height; q++) {
                         context[q] = DEFAULT;
                     }
-                    for(let j=0; j<setting.length; j++) {
-                        let kv = setting[j].split(':');
-                        let dim = kv[0];
-                        let index = allDimensions[dim];
+                    for(var j=0; j<setting.length; j++) {
+                        var kv = setting[j].split(':');
+                        var dim = kv[0];
+                        var index = allDimensions[dim];
                         if(index === undefined) {
                             console.log('WARNING: invalid dimension "' + dim +
                                 '" in settings ' + JSON.stringify(setting));
@@ -358,9 +358,9 @@ Ycb.prototype = {
                             usedValues[dim][kv[1]] = 1;
                             context[index] = kv[1];
                         } else {
-                            let vals = kv[1].split(',');
+                            var vals = kv[1].split(',');
                             context[index] = vals;
-                            for(let k=0; k<vals.length; k++) {
+                            for(var k=0; k<vals.length; k++) {
                                 usedValues[dim][vals[k]] = 1;
                             }
                         }
@@ -373,31 +373,31 @@ Ycb.prototype = {
 
     /**
      * Convert config to delta.
-     * @param config
-     * @returns {{subbed: object, unsubbed: object}}
+     * @param config {object}
+     * @returns {object}
      * @private
      */
     _buildDelta: function(config) {
         config = omit(config, 'settings');
-        let subbed = cloneDeep(config);
-        let subFlag = this._applySubstitutions(subbed, null, null);
-        let unsubbed = subFlag ? config : subbed;
+        var subbed = cloneDeep(config);
+        var subFlag = this._applySubstitutions(subbed, null, null);
+        var unsubbed = subFlag ? config : subbed;
         return {subbed:subbed, unsubbed:unsubbed};
     },
 
     /**
      * Evaluate dimensions and omit unused dimensions.
-     * @param dimensions
-     * @param usedDimensions
-     * @param usedValues
-     * @returns {int[]}
+     * @param dimensions {array}
+     * @param usedDimensions {object}
+     * @param usedValues {object}
+     * @returns {array}
      * @private
      */
     _parseDimensions: function(dimensions, usedDimensions, usedValues) {
-        let activeDimensions = new Array(dimensions.length);
+        var activeDimensions = new Array(dimensions.length);
         var valueCounter = 1;
-        for(let i=0; i<dimensions.length; i++) {
-            let dimensionName;
+        for(var i=0; i<dimensions.length; i++) {
+            var dimensionName;
             for(dimensionName in dimensions[i]){break}
             if(usedDimensions[dimensionName] === undefined) {
                 activeDimensions[i] = 0;
@@ -406,7 +406,7 @@ Ycb.prototype = {
             activeDimensions[i] = 1;
             this.dimensionsList.push(dimensionName);
             this.dimensionsToIndex[dimensionName] = i;
-            let labelCollector = {};
+            var labelCollector = {};
             valueCounter = this._dimensionWalk(dimensions[i][dimensionName], usedValues[dimensionName],
                 valueCounter, [0], this.precedenceMap, labelCollector, this.numberToValue);
             this.valueToNumber[dimensionName] = labelCollector;
@@ -417,19 +417,19 @@ Ycb.prototype = {
     /**
      * Traverse a dimension hierarchy, label dimension values, and fill the precedence map and dim <-> num maps.
      * Mark used dimension values.
-     * @param dimension
-     * @param used
-     * @param label
-     * @param path
-     * @param pathCollector
-     * @param valueToNumCollector
-     * @param numToValueCollector
-     * @returns {*}
+     * @param dimension {object}
+     * @param used {object}
+     * @param label {number}
+     * @param path {array}
+     * @param pathCollector {array}
+     * @param valueToNumCollector {object}
+     * @param numToValueCollector {array}
+     * @returns {number}
      * @private
      */
     _dimensionWalk: function(dimension, used, label, path, pathCollector, valueToNumCollector, numToValueCollector) {
         for(var key in dimension) {
-            let currentPath;
+            var currentPath;
             if(used[key]) {
                 used[key] = 2;
                 currentPath = path.concat(label);
@@ -451,28 +451,28 @@ Ycb.prototype = {
 
     /**
      * Convert config context and omit invalid dimension values.
-     * @param fullContext
-     * @param activeDimensions
-     * @param usedValues
-     * @param setting
-     * @returns
+     * @param fullContext {array}
+     * @param activeDimensions {array}
+     * @param usedValues {object}
+     * @param setting {object}
+     * @returns {array}
      * @private
      */
     _filterContext: function(fullContext, activeDimensions, usedValues, setting) {
-        let height = this.dimensionsList.length;
-        let newContext = new Array(height);
-        for(let i=0; i<height; i++) {
+        var height = this.dimensionsList.length;
+        var newContext = new Array(height);
+        for(var i=0; i<height; i++) {
             newContext[i] = 0;
         }
-        let activeIndex = 0;
-        for(let i=0; i<fullContext.length; i++) {
+        var activeIndex = 0;
+        for(i=0; i<fullContext.length; i++) {
             if(activeDimensions[i]) {
-                let dimensionName = this.dimensionsList[activeIndex];
-                let contextValue = fullContext[i];
+                var dimensionName = this.dimensionsList[activeIndex];
+                var contextValue = fullContext[i];
                 if(contextValue.constructor === Array) {
-                    let newValue = [];
-                    for(let k=0; k<contextValue.length; k++) {
-                        let valueChunk = contextValue[k];
+                    var newValue = [];
+                    for(var k=0; k<contextValue.length; k++) {
+                        var valueChunk = contextValue[k];
                         if(usedValues[dimensionName][valueChunk] === 2) {
                             newValue.push(this.valueToNumber[dimensionName][valueChunk]);
                         } else {
@@ -502,26 +502,27 @@ Ycb.prototype = {
 
     /**
      * Insert the given context and delta into the tree.
-     * @param root
-     * @param depth
-     * @param context
-     * @param delta
+     * @param root {object}
+     * @param depth {number}
+     * @param context {array}
+     * @param delta {object}
      * @private
      */
     _buildTreeHelper: function(root, depth, context, delta) {
-        let currentValue = context[depth];
-        let isMulti = currentValue.constructor === Array;
+        var i;
+        var currentValue = context[depth];
+        var isMulti = currentValue.constructor === Array;
         if(depth === context.length-1) {
             if(isMulti) {
-                for(let i=0; i<currentValue.length; i++) {
-                    let curDelta = delta;
+                for(i=0; i<currentValue.length; i++) {
+                    var curDelta = delta;
                     if(root[currentValue[i]] !== undefined) {
                         curDelta = mergeDeep(delta, root[currentValue[i]], true);
                     }
                     root[currentValue[i]] = curDelta;
                 }
             } else {
-                let curDelta = delta;
+                curDelta = delta;
                 if(root[currentValue] !== undefined) {
                     curDelta = mergeDeep(delta, root[currentValue], true);
                 }
@@ -530,7 +531,7 @@ Ycb.prototype = {
             return;
         }
         if(isMulti){
-            for(let i=0; i<currentValue.length; i++) {
+            for(i=0; i<currentValue.length; i++) {
                 if(root[currentValue[i]] === undefined) {
                     root[currentValue[i]] = {};
                 }
@@ -552,7 +553,7 @@ Ycb.prototype = {
      * @param config {object}
      * @param base {object}
      * @param parent {object}
-     * @return void
+     * @return {boolean}
      */
     _applySubstitutions: function (config, base, parent) {
         var key,
@@ -561,7 +562,7 @@ Ycb.prototype = {
             item;
         base = base || config;
         parent = parent || {ref: config, key: null};
-        let subFlag = false;
+        var subFlag = false;
 
         for (key in config) {
             if (config.hasOwnProperty(key)) {
@@ -652,12 +653,11 @@ Ycb.prototype = {
 
     /**
      * Recursive helper for walking the config tree.
-     * @param cur
-     * @param depth
-     * @param context
-     * @param callback
-     * @param stop
-     * @returns {*}
+     * @param cur {object}
+     * @param depth {number}
+     * @param context {array}
+     * @param callback {function}
+     * @param stop {array}
      * @private
      */
     _walkSettingsHelper: function(cur, depth, context, callback, stop) {
@@ -668,7 +668,7 @@ Ycb.prototype = {
             stop[0] = !callback(this._contextToObject(context), cloneDeep(cur));
             return stop[0];
         }
-        let key;
+        var key;
         for(key in cur) {
             if(this._walkSettingsHelper(cur[key], depth+1, context.concat(key), callback, stop)) {
                 return true;
@@ -709,9 +709,9 @@ module.exports = {
      */
     read: function (bundle, context, validate, debug) {
         var opts = {
-                validate: validate,
-                debug: debug
-            };
+            validate: validate,
+            debug: debug
+        };
         var ycb = new Ycb(bundle, opts);
         return ycb.read(context, opts);
     },

--- a/index.js
+++ b/index.js
@@ -111,31 +111,25 @@ Ycb.prototype = {
         }
         var value = context[depth];
         if(value.constructor !== Array) {
-            this._expand(cur, depth, context, collector, value, subKey);
+            var keys = this.precedenceMap[value];
+            var n = keys.length;
+            for(var j=0; j<n; j++) {
+                if(cur[keys[j]] !== undefined) {
+                    this._readHelper(cur[keys[j]], depth+1, context, collector, subKey);
+                }
+            }
         } else {
+            var seen = {};
             var i = value.length;
             while(i--) {
-                this._expand(cur, depth, context, collector, value[i], subKey);
-            }
-        }
-    },
-
-    /**
-     * Recurse to all children that apply to the given context.
-     * @param cur {object}
-     * @param depth {number}
-     * @param context {array}
-     * @param collector {object}
-     * @param value {number}
-     * @param subKey {string}
-     * @private
-     */
-    _expand: function(cur, depth, context, collector, value, subKey) {
-        var keys = this.precedenceMap[value];
-        var n = keys.length;
-        for(var i=0; i<n; i++) {
-            if(cur[keys[i]] !== undefined) {
-                this._readHelper(cur[keys[i]], depth+1, context, collector, subKey);
+                keys = this.precedenceMap[value[i]];
+                n = keys.length;
+                for(j=0; j<n; j++) {
+                    if(cur[keys[j]] !== undefined && seen[keys[j]] === undefined) {
+                        this._readHelper(cur[keys[j]], depth+1, context, collector, subKey);
+                        seen[keys[j]] = true;
+                    }
+                }
             }
         }
     },
@@ -171,31 +165,25 @@ Ycb.prototype = {
         }
         var value = context[depth];
         if(value.constructor !== Array) {
-            this._expandNoMerge(cur, depth, context, collector, value, subKey);
+            var keys = this.precedenceMap[value];
+            var n = keys.length;
+            for(var j=0; j<n; j++) {
+                if(cur[keys[j]] !== undefined) {
+                    this._readNoMergeHelper(cur[keys[j]], depth+1, context, collector, subKey);
+                }
+            }
         } else {
+            var seen = {};
             var i = value.length;
             while(i--) {
-                this._expandNoMerge(cur, depth, context, collector, value[i], subKey);
-            }
-        }
-    },
-
-    /**
-     * Recurse to all children that apply to the given context.
-     * @param cur {object}
-     * @param depth {number}
-     * @param context {array}
-     * @param collector {array}
-     * @param value {number}
-     * @param subKey {string}
-     * @private
-     */
-    _expandNoMerge: function(cur, depth, context, collector, value, subKey) {
-        var keys = this.precedenceMap[value];
-        var n = keys.length;
-        for(var i=0; i<n; i++) {
-            if(cur[keys[i]] !== undefined) {
-                this._readNoMergeHelper(cur[keys[i]], depth+1, context, collector, subKey);
+                keys = this.precedenceMap[value[i]];
+                n = keys.length;
+                for(j=0; j<n; j++) {
+                    if(cur[keys[j]] !== undefined && seen[keys[j]] === undefined) {
+                        this._readNoMergeHelper(cur[keys[j]], depth+1, context, collector, subKey);
+                        seen[keys[j]] = true;
+                    }
+                }
             }
         }
     },

--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ Ycb.prototype = {
     readNoMerge: function(contextObj, options) {
         var context = this._parseContext(contextObj);
         var subKey = options.applySubstitutions !== false ? 'subbed': 'unsubbed';
-        var collector = this.masterDelta ? [this.masterDelta] : [];
+        var collector = this.masterDelta ? [this.masterDelta[subKey]] : [];
         this._readNoMergeHelper(this.tree, 0, context, collector, subKey);
         return cloneDeep(collector);
     },

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ var cloneDeep = require('./lib/cloneDeep');
 var mergeDeep = require('./lib/mergeDeep');
 var isA = require('./lib/isA');
 var isIterable = require('./lib/isIterable');
+var _ = require('lodash');
+
 
 //---------------------------------------------------------------
 // UTILITY FUNCTIONS
@@ -104,7 +106,7 @@ Ycb.prototype = {
      */
     _readHelper: function(cur, depth, context, collector, subKey) {
         if(depth === context.length) {
-            mergeDeep(cur[subKey], collector);
+            mergeDeep(cur[subKey], collector, false);
             return;
         }
         var value = context[depth];

--- a/index.js
+++ b/index.js
@@ -15,8 +15,6 @@ var cloneDeep = require('./lib/cloneDeep');
 var mergeDeep = require('./lib/mergeDeep');
 var isA = require('./lib/isA');
 var isIterable = require('./lib/isIterable');
-var _ = require('lodash');
-
 
 //---------------------------------------------------------------
 // UTILITY FUNCTIONS

--- a/index.js
+++ b/index.js
@@ -175,7 +175,7 @@ Ycb.prototype = {
         } else {
             var i = value.length;
             while(i--) {
-                this._expandNoMerge(cur, depth, context, collector, value, subKey);
+                this._expandNoMerge(cur, depth, context, collector, value[i], subKey);
             }
         }
     },

--- a/index.js
+++ b/index.js
@@ -163,8 +163,7 @@ Ycb.prototype = {
     readNoMerge: function(contextObj, options) {
         let context = this._parseContext(contextObj);
         let subKey = options.applySubstitutions !== false ? 'subbed': 'unsubbed';
-        let collector;
-        collector = this.masterDelta ? this.masterDelta : [];
+        let collector = this.masterDelta ? [this.masterDelta] : [];
         this._readNoMergeHelper(this.tree, 0, context, collector, subKey);
         return cloneDeep(collector);
     },


### PR DESCRIPTION
Rewrite of library to store contexts and configurations in a trie style tree, this scales better than the current method.
Most internal methods and variables are changed so client code that relies on these will likely break, support can be added if needed. Public methods should match previous behavior in all cases.
Perf measurements based off the preexisting benchmark for reads and initial load time:

Input | YCB(ops/sec)  | Tree(ops/sec) | Improvement
--- | --- | --- | ---
Base|472,447|2,985,223|6.3x
y20 (large config / large dimensions)|29,010|245,589|8.5x
y20 (large config / small dimensions)|40,699|280,518|6.9x
y20 (small config / large dimensions)|93,800|5,046,250|53.8x
y20 (small config / small dimensions)|230,637|3,181,432|13.8x
y20 (small config / large dimensions / big context) |98,767|5,032,506|51.0x
y20 (large config / large dimensions / big context) |18,654|173,161|9.3x
y20 (medium config / jumbo dimensions / tiny context) |119,894|865,038|7.2x
y20 (medium config / jumbo dimensions / medium context) |23,115|481,654|20.8x
y20 (medium config / jumbo dimensions / bigger context)|0.46|167,406|364,000x

Input | YCB(ops/sec)  | Tree(ops/sec) | Improvement
--- | --- | --- | ---
Load Base|153,850|205,738|1.3x
Load (large config / large dimensions)|53|148|2.8x
Load (small config / large dimensions)|845|3,991|4.7x
Load (small config / small dimensions)|12,579|29,781|2.4x
Load (large config / small dimensions)|241|391|1.6x
Load (medium config / jumbo dimensions)|586|872|1.5x