### PR TITLE
fix: be defensive when given a falsy context value

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,4 +6,5 @@ rules:
   indent: [2, 4, {SwitchCase: 1}]
   quotes: [2, 'single']
   dot-notation: [2, {allowKeywords: false}]
+  no-console: 0
   no-prototype-builtins: 0

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ Ycb.prototype = {
             return;
         }
         var value = context[depth];
-        if(value.constructor !== Array) {
+        if(!Array.isArray(value)) {
             var keys = this.precedenceMap[value];
             var n = keys.length;
             for(var j=0; j<n; j++) {
@@ -162,7 +162,7 @@ Ycb.prototype = {
             return;
         }
         var value = context[depth];
-        if(value.constructor !== Array) {
+        if(!Array.isArray(value)) {
             var keys = this.precedenceMap[value];
             var n = keys.length;
             for(var j=0; j<n; j++) {
@@ -202,7 +202,7 @@ Ycb.prototype = {
             var dimension = this.dimensionsList[i];
             if(contextObj.hasOwnProperty(dimension)) {
                 var value = contextObj[dimension];
-                if(value.constructor === Array) {
+                if(Array.isArray(value)) {
                     var newValue = [];
                     for(var j=0; j<value.length; j++) {
                         var numValue = this.valueToNumber[dimension][value[j]];
@@ -454,7 +454,7 @@ Ycb.prototype = {
             if(activeDimensions[i]) {
                 var dimensionName = this.dimensionsList[activeIndex];
                 var contextValue = fullContext[i];
-                if(contextValue.constructor === Array) {
+                if(Array.isArray(contextValue)) {
                     var newValue = [];
                     for(var k=0; k<contextValue.length; k++) {
                         var valueChunk = contextValue[k];
@@ -495,7 +495,7 @@ Ycb.prototype = {
     _buildTreeHelper: function(root, depth, context, delta) {
         var i;
         var currentValue = context[depth];
-        var isMulti = currentValue.constructor === Array;
+        var isMulti = Array.isArray(currentValue);
         if(depth === context.length-1) {
             if(isMulti) {
                 for(i=0; i<currentValue.length; i++) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,33 +5,25 @@
   "requires": true,
   "dependencies": {
     "@babel/code-frame": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/code-frame/-/code-frame-7.0.0.tgz",
-      "integrity": "sha1-BuKrGb21NThVWaq7W6WXKUgoAPg=",
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/code-frame/-/code-frame-7.5.5.tgz",
+      "integrity": "sha1-vAeC9tafe31JUxIZaZuYj2aaj50=",
       "dev": true,
       "requires": {
         "@babel/highlight": "^7.0.0"
       }
     },
     "@babel/generator": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/generator/-/generator-7.5.0.tgz",
-      "integrity": "sha1-8g5LepF1Dui2NlYHPYQ9KnNtyko=",
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/generator/-/generator-7.5.5.tgz",
+      "integrity": "sha1-hzp/k2o8iUkbQ1NtEiRbYmZk488=",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.5.0",
+        "@babel/types": "^7.5.5",
         "jsesc": "^2.5.1",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/helper-function-name": {
@@ -75,9 +67,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/parser/-/parser-7.5.0.tgz",
-      "integrity": "sha1-PgcT3/ia1q43+uw7Kdz8XJeXcLc=",
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/parser/-/parser-7.5.5.tgz",
+      "integrity": "sha1-AvB3rIgX099Kgy71neZ1Zeccyks=",
       "dev": true
     },
     "@babel/template": {
@@ -92,37 +84,37 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/traverse/-/traverse-7.5.0.tgz",
-      "integrity": "sha1-QhbWWGhU71w8RZLatW7H63hIVIU=",
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/traverse/-/traverse-7.5.5.tgz",
+      "integrity": "sha1-9mT482jtMpiM1kjan3LVynDxZbs=",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.5.0",
+        "@babel/code-frame": "^7.5.5",
+        "@babel/generator": "^7.5.5",
         "@babel/helper-function-name": "^7.1.0",
         "@babel/helper-split-export-declaration": "^7.4.4",
-        "@babel/parser": "^7.5.0",
-        "@babel/types": "^7.5.0",
+        "@babel/parser": "^7.5.5",
+        "@babel/types": "^7.5.5",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
-        "lodash": "^4.17.11"
+        "lodash": "^4.17.13"
       }
     },
     "@babel/types": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/types/-/types-7.5.0.tgz",
-      "integrity": "sha1-5H1DhAwuf5EFvE06LDcbTQx4Mqs=",
+      "version": "7.5.5",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/@babel/types/-/types-7.5.5.tgz",
+      "integrity": "sha1-l7n3KOGCeFkJqkq1YmTwkKAo0Yo=",
       "dev": true,
       "requires": {
         "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
       }
     },
     "acorn": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/acorn/-/acorn-6.2.0.tgz",
-      "integrity": "sha1-Z/DaL8M51s+11vskT9RJ8zzYu+M=",
+      "version": "6.3.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/acorn/-/acorn-6.3.0.tgz",
+      "integrity": "sha1-AIdQkRn/pPwKAEHR6TpBfmjLhW4=",
       "dev": true
     },
     "acorn-jsx": {
@@ -132,9 +124,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha1-kNDVRDnaWHzX6EO/twRfUL0ivfE=",
+      "version": "6.10.2",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ajv/-/ajv-6.10.2.tgz",
+      "integrity": "sha1-086gTWsBeyiUrWkED+yLYj60vVI=",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -150,20 +142,23 @@
       "dev": true
     },
     "ansi-escapes": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
-      "integrity": "sha1-h4C5j/nb9WOBUtHx/lwde0RCl2s=",
-      "dev": true
+      "version": "4.2.1",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-escapes/-/ansi-escapes-4.2.1.tgz",
+      "integrity": "sha1-TczbhGw+7hD21k3qZic+q5DDcig=",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.5.2"
+      }
     },
     "ansi-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-regex/-/ansi-regex-3.0.0.tgz",
-      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
       "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
       "dev": true,
       "requires": {
@@ -187,8 +182,8 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "resolved": "https://registry.npm.ouroath.com/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
@@ -202,14 +197,14 @@
     },
     "balanced-match": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "resolved": "https://registry.npm.ouroath.com/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
       "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
@@ -218,7 +213,7 @@
     },
     "browser-stdout": {
       "version": "1.3.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true
     },
@@ -240,9 +235,15 @@
       "integrity": "sha1-s2MKvYlDQy9Us/BRkjjjPNffL3M=",
       "dev": true
     },
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
+      "dev": true
+    },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/chalk/-/chalk-2.4.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
       "dev": true,
       "requires": {
@@ -258,29 +259,58 @@
       "dev": true
     },
     "cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha1-JkMFp65JDR0Dvwybp8kl0XU68wc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^2.0.0"
+        "restore-cursor": "^3.1.0"
       }
     },
     "cli-width": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npm.ouroath.com/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.ouroath.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npm.ouroath.com/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        }
+      }
+    },
     "code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
     },
     "color-convert": {
       "version": "1.9.3",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/color-convert/-/color-convert-1.9.3.tgz",
+      "resolved": "https://registry.npm.ouroath.com/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
       "dev": true,
       "requires": {
@@ -289,32 +319,32 @@
     },
     "color-name": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/color-name/-/color-name-1.1.3.tgz",
+      "resolved": "https://registry.npm.ouroath.com/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "commander": {
       "version": "2.20.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/commander/-/commander-2.20.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/commander/-/commander-2.20.0.tgz",
       "integrity": "sha1-1YuytcHuj4ew00ACfp6U4iLFpCI=",
       "dev": true,
       "optional": true
     },
     "commondir": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/commondir/-/commondir-1.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.6.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/convert-source-map/-/convert-source-map-1.6.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/convert-source-map/-/convert-source-map-1.6.0.tgz",
       "integrity": "sha1-UbU3qMQ+DwTewZk7/83VBOdYrCA=",
       "dev": true,
       "requires": {
@@ -349,7 +379,7 @@
     },
     "debug": {
       "version": "4.1.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/debug/-/debug-4.1.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/debug/-/debug-4.1.1.tgz",
       "integrity": "sha1-O3ImAlUQnGtYnO4FDx1RYTlmR5E=",
       "dev": true,
       "requires": {
@@ -358,13 +388,13 @@
     },
     "decamelize": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "resolved": "https://registry.npm.ouroath.com/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
@@ -379,7 +409,7 @@
     },
     "define-properties": {
       "version": "1.1.3",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/define-properties/-/define-properties-1.1.3.tgz",
+      "resolved": "https://registry.npm.ouroath.com/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
       "dev": true,
       "requires": {
@@ -388,7 +418,7 @@
     },
     "diff": {
       "version": "3.5.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/diff/-/diff-3.5.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/diff/-/diff-3.5.0.tgz",
       "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
@@ -402,14 +432,14 @@
       }
     },
     "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+      "version": "8.0.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
       "dev": true
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
       "dev": true,
       "requires": {
@@ -418,7 +448,7 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
       "dev": true,
       "requires": {
@@ -427,7 +457,7 @@
     },
     "es-abstract": {
       "version": "1.13.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/es-abstract/-/es-abstract-1.13.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/es-abstract/-/es-abstract-1.13.0.tgz",
       "integrity": "sha1-rIYUX91QmdjdSVWMy6Lq+biOJOk=",
       "dev": true,
       "requires": {
@@ -441,7 +471,7 @@
     },
     "es-to-primitive": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
       "integrity": "sha1-7fckeAM0VujdqO8J4ArZZQcH83c=",
       "dev": true,
       "requires": {
@@ -458,18 +488,18 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "resolved": "https://registry.npm.ouroath.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
     "eslint": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/eslint/-/eslint-6.0.1.tgz",
-      "integrity": "sha1-SjIYHXLLmZ1vVBUd99M3Ex+Bzac=",
+      "version": "5.16.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/eslint/-/eslint-5.16.0.tgz",
+      "integrity": "sha1-oeOsGq5KP72Clvz496tzFMu2q+o=",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "ajv": "^6.10.0",
+        "ajv": "^6.9.1",
         "chalk": "^2.1.0",
         "cross-spawn": "^6.0.5",
         "debug": "^4.0.1",
@@ -477,19 +507,18 @@
         "eslint-scope": "^4.0.3",
         "eslint-utils": "^1.3.1",
         "eslint-visitor-keys": "^1.0.0",
-        "espree": "^6.0.0",
+        "espree": "^5.0.1",
         "esquery": "^1.0.1",
         "esutils": "^2.0.2",
         "file-entry-cache": "^5.0.1",
         "functional-red-black-tree": "^1.0.1",
-        "glob-parent": "^3.1.0",
+        "glob": "^7.1.2",
         "globals": "^11.7.0",
         "ignore": "^4.0.6",
         "import-fresh": "^3.0.0",
         "imurmurhash": "^0.1.4",
         "inquirer": "^6.2.2",
-        "is-glob": "^4.0.0",
-        "js-yaml": "^3.13.1",
+        "js-yaml": "^3.13.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "levn": "^0.3.0",
         "lodash": "^4.17.11",
@@ -497,6 +526,7 @@
         "mkdirp": "^0.5.1",
         "natural-compare": "^1.4.0",
         "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
         "progress": "^2.0.0",
         "regexpp": "^2.0.1",
         "semver": "^5.5.1",
@@ -504,18 +534,6 @@
         "strip-json-comments": "^2.0.1",
         "table": "^5.2.3",
         "text-table": "^0.2.0"
-      },
-      "dependencies": {
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
       }
     },
     "eslint-scope": {
@@ -529,21 +547,24 @@
       }
     },
     "eslint-utils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/eslint-utils/-/eslint-utils-1.3.1.tgz",
-      "integrity": "sha1-moUbqJ7nxGA0b5fPiTnHKYgn5RI=",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/eslint-utils/-/eslint-utils-1.4.0.tgz",
+      "integrity": "sha1-4sPI26doQl+JfPD55R/i4kFIXUw=",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.0.0"
+      }
     },
     "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha1-PzGA+y4pEBdxastMnW1bXDSmqB0=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+      "integrity": "sha1-4qgs6oT/JGrW+1f5veW0ZiFFnsI=",
       "dev": true
     },
     "espree": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/espree/-/espree-6.0.0.tgz",
-      "integrity": "sha1-cW/B9aJF71uaf9sdew0/AjIudfY=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha1-XWUm+k/H8HiKXPdbFfMDI+L4H3o=",
       "dev": true,
       "requires": {
         "acorn": "^6.0.7",
@@ -553,13 +574,13 @@
     },
     "esprima": {
       "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "resolved": "https://registry.npm.ouroath.com/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE=",
       "dev": true
     },
     "esquery": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/esquery/-/esquery-1.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/esquery/-/esquery-1.0.1.tgz",
       "integrity": "sha1-QGxRZYsfWZGl+bYrHcJbAOPlxwg=",
       "dev": true,
       "requires": {
@@ -568,7 +589,7 @@
     },
     "esrecurse": {
       "version": "4.2.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/esrecurse/-/esrecurse-4.2.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/esrecurse/-/esrecurse-4.2.1.tgz",
       "integrity": "sha1-AHo7n9vCs7uH5IeeoZyS/b05Qs8=",
       "dev": true,
       "requires": {
@@ -576,15 +597,15 @@
       }
     },
     "estraverse": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha1-OYrT88WiSUi+dyXoPRGn3ijNvR0=",
       "dev": true
     },
     "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha1-dNLrTeC42hKTcRkQ1Qd1ubcQ72Q=",
       "dev": true
     },
     "execa": {
@@ -603,9 +624,9 @@
       }
     },
     "external-editor": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/external-editor/-/external-editor-3.0.3.tgz",
-      "integrity": "sha1-WGbbKal4Jtvkvzr9JAcOrZ6kOic=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha1-ywP3QL764D6k0oPK7SdBqD8zVJU=",
       "dev": true,
       "requires": {
         "chardet": "^0.7.0",
@@ -615,26 +636,26 @@
     },
     "fast-deep-equal": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "resolved": "https://registry.npm.ouroath.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
     "figures": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/figures/-/figures-2.0.0.tgz",
-      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/figures/-/figures-3.0.0.tgz",
+      "integrity": "sha1-dWJ1yWRkYWPMb5GXx6ApXb/QTek=",
       "dev": true,
       "requires": {
         "escape-string-regexp": "^1.0.5"
@@ -676,14 +697,6 @@
       "dev": true,
       "requires": {
         "is-buffer": "~2.0.3"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-buffer/-/is-buffer-2.0.3.tgz",
-          "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU=",
-          "dev": true
-        }
       }
     },
     "flat-cache": {
@@ -727,19 +740,19 @@
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
       "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
@@ -760,7 +773,7 @@
     },
     "glob": {
       "version": "7.1.4",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/glob/-/glob-7.1.4.tgz",
+      "resolved": "https://registry.npm.ouroath.com/glob/-/glob-7.1.4.tgz",
       "integrity": "sha1-qmCKL2xXetNX4a5aXCbZqNGWklU=",
       "dev": true,
       "requires": {
@@ -772,57 +785,62 @@
         "path-is-absolute": "^1.0.0"
       }
     },
-    "glob-parent": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/glob-parent/-/glob-parent-3.1.0.tgz",
-      "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-      "dev": true,
-      "requires": {
-        "is-glob": "^3.1.0",
-        "path-dirname": "^1.0.0"
-      },
-      "dependencies": {
-        "is-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-glob/-/is-glob-3.1.0.tgz",
-          "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^2.1.0"
-          }
-        }
-      }
-    },
     "globals": {
       "version": "11.12.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/globals/-/globals-11.12.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/globals/-/globals-11.12.0.tgz",
       "integrity": "sha1-q4eVM4hooLq9hSV1gBjCp+uVxC4=",
       "dev": true
     },
     "graceful-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/graceful-fs/-/graceful-fs-4.2.0.tgz",
-      "integrity": "sha1-jY/cc5d8sEEEchy1NmbBymTNMos=",
+      "version": "4.2.2",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/graceful-fs/-/graceful-fs-4.2.2.tgz",
+      "integrity": "sha1-bwlSYF0BQMHP2xOO0AV3W5LWewI=",
       "dev": true
     },
     "growl": {
       "version": "1.10.5",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/growl/-/growl-1.10.5.tgz",
+      "resolved": "https://registry.npm.ouroath.com/growl/-/growl-1.10.5.tgz",
       "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
       "dev": true
     },
+    "handlebars": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npm.ouroath.com/handlebars/-/handlebars-4.1.2.tgz",
+      "integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
+      "dev": true,
+      "requires": {
+        "neo-async": "^2.6.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.6.1",
+        "uglify-js": "^3.1.4"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npm.ouroath.com/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/has/-/has-1.0.3.tgz",
+      "resolved": "https://registry.npm.ouroath.com/has/-/has-1.0.3.tgz",
       "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
       "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
     },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npm.ouroath.com/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
     "has-symbols": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/has-symbols/-/has-symbols-1.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/has-symbols/-/has-symbols-1.0.0.tgz",
       "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
       "dev": true
     },
@@ -837,19 +855,19 @@
     },
     "he": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/he/-/he-1.2.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/he/-/he-1.2.0.tgz",
       "integrity": "sha1-hK5l+n6vsWX922FWauFLrwVmTw8=",
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
-      "integrity": "sha1-l/I2l3vW4SVAiTD/bePuxigewEc=",
+      "version": "2.8.4",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
+      "integrity": "sha1-RBGauvS8ZGkqFqzjRwD+2cA+JUY=",
       "dev": true
     },
     "iconv-lite": {
       "version": "0.4.24",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "resolved": "https://registry.npm.ouroath.com/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
       "dev": true,
       "requires": {
@@ -874,13 +892,13 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "resolved": "https://registry.npm.ouroath.com/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "resolved": "https://registry.npm.ouroath.com/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
@@ -889,38 +907,32 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
       "dev": true
     },
     "inquirer": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/inquirer/-/inquirer-6.4.1.tgz",
-      "integrity": "sha1-e9nlqwVnzSO0GwGAto4M+oL8PAs=",
+      "version": "6.5.1",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/inquirer/-/inquirer-6.5.1.tgz",
+      "integrity": "sha1-i/t6WsAtrG/2QaxMX/F9oRL820I=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^3.2.0",
+        "ansi-escapes": "^4.2.1",
         "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
+        "cli-cursor": "^3.1.0",
         "cli-width": "^2.0.0",
         "external-editor": "^3.0.3",
-        "figures": "^2.0.0",
-        "lodash": "^4.17.11",
-        "mute-stream": "0.0.7",
+        "figures": "^3.0.0",
+        "lodash": "^4.17.15",
+        "mute-stream": "0.0.8",
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
-        "string-width": "^2.1.0",
+        "string-width": "^4.1.0",
         "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-          "dev": true
-        },
         "strip-ansi": {
           "version": "5.2.0",
           "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -940,52 +952,43 @@
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npm.ouroath.com/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha1-Ts8/z3ScvR5HJonhCaxmJhol5yU=",
       "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-callable/-/is-callable-1.1.4.tgz",
+      "resolved": "https://registry.npm.ouroath.com/is-callable/-/is-callable-1.1.4.tgz",
       "integrity": "sha1-HhrfIZ4e62hNaR+dagX/DTCiTXU=",
       "dev": true
     },
     "is-date-object": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-date-object/-/is-date-object-1.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/is-date-object/-/is-date-object-1.0.1.tgz",
       "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
       "dev": true
     },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
-    },
     "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
       "dev": true
-    },
-    "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha1-dWfb6fL14kZ7x3q4PEopSCQHpdw=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
     },
     "is-promise": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-promise/-/is-promise-2.1.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-regex/-/is-regex-1.0.4.tgz",
+      "resolved": "https://registry.npm.ouroath.com/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "dev": true,
       "requires": {
@@ -994,13 +997,13 @@
     },
     "is-stream": {
       "version": "1.1.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-stream/-/is-stream-1.1.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
       "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-symbol/-/is-symbol-1.0.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/is-symbol/-/is-symbol-1.0.2.tgz",
       "integrity": "sha1-oFX2rlcZLK7jKeeoYBGLSXqVDzg=",
       "dev": true,
       "requires": {
@@ -1009,7 +1012,7 @@
     },
     "isexe": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
@@ -1044,9 +1047,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/semver/-/semver-6.2.0.tgz",
-          "integrity": "sha1-TYE9lZCq+KkZJpPWyFuTRN5ZAds=",
+          "version": "6.3.0",
+          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha1-7gpkyK9ejO6mdoexM3YeG+y9HT0=",
           "dev": true
         }
       }
@@ -1062,12 +1065,6 @@
         "supports-color": "^6.1.0"
       },
       "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
         "supports-color": {
           "version": "6.1.0",
           "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/supports-color/-/supports-color-6.1.0.tgz",
@@ -1094,7 +1091,7 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npm.ouroath.com/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
@@ -1107,37 +1104,6 @@
       "dev": true,
       "requires": {
         "handlebars": "^4.1.2"
-      },
-      "dependencies": {
-        "handlebars": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/handlebars/-/handlebars-4.1.2.tgz",
-          "integrity": "sha1-trN8HO0DBrIh4JT8eso+wjsTG2c=",
-          "dev": true,
-          "requires": {
-            "neo-async": "^2.6.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-          "dev": true
-        },
-        "uglify-js": {
-          "version": "3.6.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/uglify-js/-/uglify-js-3.6.0.tgz",
-          "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "commander": "~2.20.0",
-            "source-map": "~0.6.1"
-          }
-        }
       }
     },
     "js-tokens": {
@@ -1146,27 +1112,37 @@
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
       "dev": true
     },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npm.ouroath.com/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/jsesc/-/jsesc-2.5.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha1-gFZNLkg9rPbo7yCWUKZ98/DCg6Q=",
       "dev": true
     },
     "json-parse-better-errors": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.4.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha1-afaofZUTq4u4/mO9sJecRI5oRmA=",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
@@ -1181,7 +1157,7 @@
     },
     "levn": {
       "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
@@ -1203,7 +1179,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npm.ouroath.com/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -1220,9 +1196,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha1-s56mIp72B+zYniyN8SU2iRysm40=",
+      "version": "4.17.15",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
       "dev": true
     },
     "lodash.flattendeep": {
@@ -1242,7 +1218,7 @@
     },
     "lru-cache": {
       "version": "4.1.5",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/lru-cache/-/lru-cache-4.1.5.tgz",
+      "resolved": "https://registry.npm.ouroath.com/lru-cache/-/lru-cache-4.1.5.tgz",
       "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
       "dev": true,
       "requires": {
@@ -1278,14 +1254,6 @@
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
         "p-is-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "mimic-fn": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
-          "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
-          "dev": true
-        }
       }
     },
     "merge-source-map": {
@@ -1299,22 +1267,22 @@
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/source-map/-/source-map-0.6.1.tgz",
+          "resolved": "https://registry.npm.ouroath.com/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
           "dev": true
         }
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha1-ftLCzMyvhNP/y3pptXcR/CCDQBs=",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "resolved": "https://registry.npm.ouroath.com/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -1322,13 +1290,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npm.ouroath.com/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -1336,9 +1304,9 @@
       }
     },
     "mocha": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/mocha/-/mocha-6.1.4.tgz",
-      "integrity": "sha1-41+tokLVQ0p+Fj1VXHBfaHWVFkA=",
+      "version": "6.2.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/mocha/-/mocha-6.2.0.tgz",
+      "integrity": "sha1-+Ja2QoQ0RdG7i8pg6r2SBriRblY=",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -1366,35 +1334,6 @@
         "yargs-unparser": "1.5.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "2.1.1",
-              "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/string-width/-/string-width-2.1.1.tgz",
-              "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
-              "dev": true,
-              "requires": {
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^4.0.0"
-              }
-            }
-          }
-        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/debug/-/debug-3.2.6.tgz",
@@ -1418,49 +1357,11 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
         "ms": {
           "version": "2.1.1",
           "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ms/-/ms-2.1.1.tgz",
           "integrity": "sha1-MKWGTrPrsKZvLr5tcnrwagnYbgo=",
           "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          },
-          "dependencies": {
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            }
-          }
         },
         "supports-color": {
           "version": "6.0.0",
@@ -1470,49 +1371,30 @@
           "requires": {
             "has-flag": "^3.0.0"
           }
-        },
-        "yargs": {
-          "version": "13.2.2",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/yargs/-/yargs-13.2.2.tgz",
-          "integrity": "sha1-DBAfWArpXOp/Odkn53cOP9yX+ZM=",
-          "dev": true,
-          "requires": {
-            "cliui": "^4.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.0.0"
-          }
         }
       }
     },
     "ms": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ms/-/ms-2.1.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/ms/-/ms-2.1.2.tgz",
       "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
       "dev": true
     },
     "mute-stream": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/mute-stream/-/mute-stream-0.0.7.tgz",
-      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "version": "0.0.8",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
       "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/natural-compare/-/natural-compare-1.4.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
     },
     "neo-async": {
       "version": "2.6.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/neo-async/-/neo-async-2.6.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/neo-async/-/neo-async-2.6.1.tgz",
       "integrity": "sha1-rCetpmFn+ohJpq3dg39rGJrSCBw=",
       "dev": true
     },
@@ -1540,7 +1422,7 @@
     },
     "normalize-package-data": {
       "version": "2.5.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
       "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
       "dev": true,
       "requires": {
@@ -1548,22 +1430,11 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.11.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/resolve/-/resolve-1.11.1.tgz",
-          "integrity": "sha1-6hDYEQN2mC/vV434/DC5rDCgej4=",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        }
       }
     },
     "npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
@@ -1572,7 +1443,7 @@
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
@@ -1607,108 +1478,11 @@
         "uuid": "^3.3.2",
         "yargs": "^13.2.2",
         "yargs-parser": "^13.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
-          "dev": true
-        },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha1-3u/P2y6AB4SqNPRvoI4GhRx7u8U=",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.13.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/js-yaml/-/js-yaml-3.13.1.tgz",
-          "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha1-H9H2cjXVttD+54EFYAG/tpTAOwk=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.2.4",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/yargs/-/yargs-13.2.4.tgz",
-          "integrity": "sha1-C1YreUAW65ZRuYvTes82SqXW3IM=",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "os-locale": "^3.1.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.0"
-          },
-          "dependencies": {
-            "yargs-parser": {
-              "version": "13.1.1",
-              "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/yargs-parser/-/yargs-parser-13.1.1.tgz",
-              "integrity": "sha1-0mBYUyqgbTZf4JH2ofwGsvfl7KA=",
-              "dev": true,
-              "requires": {
-                "camelcase": "^5.0.0",
-                "decamelize": "^1.2.0"
-              }
-            }
-          }
-        }
       }
     },
     "object-keys": {
       "version": "1.1.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/object-keys/-/object-keys-1.1.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
       "dev": true
     },
@@ -1736,7 +1510,7 @@
     },
     "once": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
@@ -1744,17 +1518,17 @@
       }
     },
     "onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/onetime/-/onetime-5.1.0.tgz",
+      "integrity": "sha1-//DzyRYX/mK7UBiWNumayKbfe+U=",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "mimic-fn": "^2.1.0"
       }
     },
     "optimist": {
       "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
@@ -1764,7 +1538,7 @@
       "dependencies": {
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "resolved": "https://registry.npm.ouroath.com/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
           "dev": true
         }
@@ -1772,7 +1546,7 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
@@ -1786,7 +1560,7 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/os-homedir/-/os-homedir-1.0.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/os-homedir/-/os-homedir-1.0.2.tgz",
       "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
       "dev": true
     },
@@ -1803,7 +1577,7 @@
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
@@ -1815,7 +1589,7 @@
     },
     "p-finally": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/p-finally/-/p-finally-1.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
       "dev": true
     },
@@ -1872,7 +1646,7 @@
     },
     "parse-json": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/parse-json/-/parse-json-4.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
       "dev": true,
       "requires": {
@@ -1880,33 +1654,33 @@
         "json-parse-better-errors": "^1.0.1"
       }
     },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
-    },
     "path-exists": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/path-exists/-/path-exists-3.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npm.ouroath.com/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
       "dev": true
     },
     "path-key": {
       "version": "2.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/path-key/-/path-key-2.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.6",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/path-parse/-/path-parse-1.0.6.tgz",
+      "resolved": "https://registry.npm.ouroath.com/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha1-1i27VnlAXXLEc37FhgDp3c8G0kw=",
       "dev": true
     },
@@ -1921,7 +1695,7 @@
       "dependencies": {
         "pify": {
           "version": "3.0.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/pify/-/pify-3.0.0.tgz",
+          "resolved": "https://registry.npm.ouroath.com/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
         }
@@ -1944,19 +1718,19 @@
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
     "progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/progress/-/progress-2.0.3.tgz",
+      "resolved": "https://registry.npm.ouroath.com/progress/-/progress-2.0.3.tgz",
       "integrity": "sha1-foz42PW48jnBvGi+tOt4Vn1XLvg=",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/pseudomap/-/pseudomap-1.0.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
@@ -1972,7 +1746,7 @@
     },
     "punycode": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/punycode/-/punycode-2.1.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew=",
       "dev": true
     },
@@ -2014,7 +1788,7 @@
     },
     "require-directory": {
       "version": "2.1.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/require-directory/-/require-directory-2.1.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
@@ -2024,6 +1798,15 @@
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha1-P8ZEo1yEpIVUYJ/ybsUrZvpXffY=",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
     "resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2031,18 +1814,18 @@
       "dev": true
     },
     "restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha1-OfZ8VLOnpYzqUjbZXPADQjljH34=",
       "dev": true,
       "requires": {
-        "onetime": "^2.0.0",
+        "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
     },
     "rimraf": {
       "version": "2.6.3",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/rimraf/-/rimraf-2.6.3.tgz",
+      "resolved": "https://registry.npm.ouroath.com/rimraf/-/rimraf-2.6.3.tgz",
       "integrity": "sha1-stEE/g2Psnz54KHNqCYt04M8bKs=",
       "dev": true,
       "requires": {
@@ -2051,7 +1834,7 @@
     },
     "run-async": {
       "version": "2.3.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/run-async/-/run-async-2.3.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
       "dev": true,
       "requires": {
@@ -2069,31 +1852,31 @@
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
       "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
       "dev": true
     },
     "semver": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/semver/-/semver-5.7.0.tgz",
-      "integrity": "sha1-eQp89v6lRZuslhELKbYEEtyP+Ws=",
+      "version": "5.7.1",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/set-blocking/-/set-blocking-2.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
       "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/shebang-command/-/shebang-command-1.2.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
@@ -2102,13 +1885,13 @@
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/signal-exit/-/signal-exit-3.0.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
@@ -2121,7 +1904,21 @@
         "ansi-styles": "^3.2.0",
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.ouroath.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        }
       }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npm.ouroath.com/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "spawn-wrap": {
       "version": "1.4.2",
@@ -2139,7 +1936,7 @@
     },
     "spdx-correct": {
       "version": "3.1.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/spdx-correct/-/spdx-correct-3.1.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/spdx-correct/-/spdx-correct-3.1.0.tgz",
       "integrity": "sha1-+4PlBERSaPFUsHTiGMh8ADzTHfQ=",
       "dev": true,
       "requires": {
@@ -2149,13 +1946,13 @@
     },
     "spdx-exceptions": {
       "version": "2.2.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
       "integrity": "sha1-LqRQrudPKom/uUUZwH/Nb0EyKXc=",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "integrity": "sha1-meEZt6XaAOBUkcn6M4t5BII7QdA=",
       "dev": true,
       "requires": {
@@ -2164,45 +1961,65 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha1-dezRqI3owYTvAV6vtRtbSL/RG7E=",
+      "version": "3.0.5",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha1-NpS1gEVnpFjTyARYQqY1hjL2JlQ=",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "resolved": "https://registry.npm.ouroath.com/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/string-width/-/string-width-4.1.0.tgz",
+      "integrity": "sha1-uoRtHaqXw8WWFVMIBj4HXtHJmv8=",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^5.2.0"
+      },
+      "dependencies": {
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
     },
     "strip-ansi": {
       "version": "4.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
         "ansi-regex": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npm.ouroath.com/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        }
       }
     },
     "strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/strip-bom/-/strip-bom-3.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/strip-bom/-/strip-bom-3.0.0.tgz",
       "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
       "dev": true
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -2214,37 +2031,35 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        }
       }
     },
     "table": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/table/-/table-5.4.1.tgz",
-      "integrity": "sha1-BpGuLr6CWYWO+2PlULbV+TABceg=",
+      "version": "5.4.5",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/table/-/table-5.4.5.tgz",
+      "integrity": "sha1-yPTqLY/uCMACf6wnsOwKT+Ad+kI=",
       "dev": true,
       "requires": {
-        "ajv": "^6.9.1",
-        "lodash": "^4.17.11",
+        "ajv": "^6.10.2",
+        "lodash": "^4.17.14",
         "slice-ansi": "^2.1.0",
         "string-width": "^3.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha1-i5+PCM8ay4Q3Vqg5yox+MWjFGZc=",
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.ouroath.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "string-width": {
@@ -2283,19 +2098,19 @@
     },
     "text-table": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npm.ouroath.com/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
     "tmp": {
       "version": "0.0.33",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/tmp/-/tmp-0.0.33.tgz",
+      "resolved": "https://registry.npm.ouroath.com/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
       "dev": true,
       "requires": {
@@ -2304,13 +2119,13 @@
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/trim-right/-/trim-right-1.0.1.tgz",
+      "resolved": "https://registry.npm.ouroath.com/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
     },
@@ -2322,16 +2137,42 @@
     },
     "type-check": {
       "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
     },
+    "type-fest": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/type-fest/-/type-fest-0.5.2.tgz",
+      "integrity": "sha1-1u9CoDVsbNRfSUhcO2KB/BSOSKI=",
+      "dev": true
+    },
+    "uglify-js": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/uglify-js/-/uglify-js-3.6.0.tgz",
+      "integrity": "sha1-cEaBNFxTqLIHn7bOwpSwXq0kL/U=",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "commander": "~2.20.0",
+        "source-map": "~0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npm.ouroath.com/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+          "dev": true,
+          "optional": true
+        }
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/uri-js/-/uri-js-4.2.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
       "dev": true,
       "requires": {
@@ -2340,13 +2181,13 @@
     },
     "uuid": {
       "version": "3.3.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/uuid/-/uuid-3.3.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/uuid/-/uuid-3.3.2.tgz",
       "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE=",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "resolved": "https://registry.npm.ouroath.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
       "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
       "dev": true,
       "requires": {
@@ -2356,8 +2197,8 @@
     },
     "which": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "resolved": "https://registry.npm.ouroath.com/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
@@ -2365,7 +2206,7 @@
     },
     "which-module": {
       "version": "2.0.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/which-module/-/which-module-2.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/which-module/-/which-module-2.0.0.tgz",
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
@@ -2376,17 +2217,35 @@
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.ouroath.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npm.ouroath.com/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        }
       }
     },
     "wordwrap": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "https://registry.npm.ouroath.com/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
@@ -2396,13 +2255,13 @@
       "dependencies": {
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": "https://registry.npm.ouroath.com/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": "https://registry.npm.ouroath.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
@@ -2411,7 +2270,7 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/string-width/-/string-width-1.0.2.tgz",
+          "resolved": "https://registry.npm.ouroath.com/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
@@ -2422,7 +2281,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npm.ouroath.com/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -2433,7 +2292,7 @@
     },
     "wrappy": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
       "dev": true
     },
@@ -2448,7 +2307,7 @@
     },
     "write-file-atomic": {
       "version": "2.4.3",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "resolved": "https://registry.npm.ouroath.com/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
       "integrity": "sha1-H9Lprh3z51uNjDZ0Q8aS1MqB9IE=",
       "dev": true,
       "requires": {
@@ -2465,9 +2324,62 @@
     },
     "yallist": {
       "version": "2.1.2",
-      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/yallist/-/yallist-2.1.2.tgz",
+      "resolved": "https://registry.npm.ouroath.com/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha1-DBAfWArpXOp/Odkn53cOP9yX+ZM=",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/emoji-regex/-/emoji-regex-7.0.3.tgz",
+          "integrity": "sha1-kzoEBShgyF6DwSJHnEdIqOTHIVY=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.ouroath.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha1-InZ74htirxCBV0MG9prFG2IgOWE=",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha1-jJpTb+tq/JYr36WxBKUJHBrZwK4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
     },
     "yargs-parser": {
       "version": "13.0.0",
@@ -2477,14 +2389,6 @@
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
-          "dev": true
-        }
       }
     },
     "yargs-unparser": {
@@ -2498,34 +2402,33 @@
         "yargs": "^12.0.5"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha1-48mzFWnhBoEd8kL3FXJaH0xJQyA=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/cliui/-/cliui-4.1.0.tgz",
-          "integrity": "sha1-NIQi2+gtgAswIu709qwQvy5NG0k=",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
-          }
-        },
         "get-caller-file": {
           "version": "1.0.3",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "resolved": "https://registry.npm.ouroath.com/get-caller-file/-/get-caller-file-1.0.3.tgz",
           "integrity": "sha1-+Xj6TJDR3+f/LWvtoqUV5xO9z0o=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npm.ouroath.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": "https://registry.npm.vzbuilders.com:4443/npm-registry/api/npm/npm-registry/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "resolved": "https://registry.npm.ouroath.com/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
           "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npm.ouroath.com/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
         },
         "yargs": {
           "version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "npm": ">1.0"
   },
   "devDependencies": {
-    "eslint": "^6.0.1",
+    "eslint": "^5.0.0",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1"
   },

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -61,6 +61,14 @@ describe('ycb unit tests', function () {
             cmp([0,6,9], ycb._parseContext({flavor:'bt', region:'ir'}));
             cmp([2,7,8], ycb._parseContext({lang:'fr_FR', region:'fr', flavor:'att'}));
         });
+        it('should handle an undefined context value', function () {
+            var bundle, ycb;
+            bundle = readFixtureFile('dimensions.json')
+                .concat(readFixtureFile('simple-1.json'))
+                .concat(readFixtureFile('simple-3.json'));
+            ycb = new libycb.Ycb(bundle);
+            cmp([0, 0, 0], ycb._parseContext({ region: undefined }));
+        });
     });
 
     describe('_processRawBundle', function () {


### PR DESCRIPTION
@redonkulus @BillDorn when given a falsy context value, `value.constructor === Array` throws a runtime error.  We can instead use `Array.isArray` which is probably a bit neater anyhow.

It's possible that we could also fix this by putting an early return/continue before any such falsy values but given my limited familiarity with this repo I'd rather keep the scope of the change small.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
