### PR TITLE
Handle wildcards in multi-value settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -881,6 +881,8 @@ Ycb.prototype = {
                         var valueChunk = contextValue[k];
                         if(usedValues[dimensionName][valueChunk] === 2) {
                             newValue.push(this.valueToNumber[dimensionName][valueChunk]);
+                        } else if(valueChunk === DEFAULT) {
+                            newValue.push(0);
                         } else {
                             logBundleWarning(configIndex, 'invalid value ' + valueChunk + ' for dimension ' + dimensionName,
                                 JSON.stringify(setting));

--- a/tests/fixtures/wildcard.json
+++ b/tests/fixtures/wildcard.json
@@ -1,0 +1,48 @@
+[
+  {
+    "dimensions": [
+      {
+        "lang": {
+          "en":null,
+          "fr": {
+            "fr_FR": {
+              "fr_CA": null
+            }
+          }
+        }
+      },
+      {
+        "region": {
+          "us": null,
+          "fr": null
+        }
+      },
+      {
+        "flavor": {
+          "att": null,
+          "bt": null
+        }
+      }
+    ]
+  },
+  {
+    "settings": ["region:*"],
+    "val1": 1
+  },
+  {
+    "settings": ["region:fr","flavor:*"],
+    "val2": 1
+  },
+  {
+    "settings": ["region:fr","flavor:att,bt"],
+    "val3": 1
+  },
+  {
+    "settings": ["region:fr","flavor:att,*"],
+    "val4": 1
+  },
+  {
+    "settings": ["lang:en,*,*,*,*"],
+    "val5": 1
+  }
+]

--- a/tests/unit/index.js
+++ b/tests/unit/index.js
@@ -522,6 +522,20 @@ describe('ycb unit tests', function () {
             assert.equal(80, config.appPort);
         });
 
+        it('should handle wildcard settings', function () {
+            var bundle,
+                ycb,
+                config;
+            bundle = readFixtureFile('wildcard.json');
+            ycb = new libycb.Ycb(bundle);
+            config = ycb.read({});
+            cmp(config, {val1:1, val5:1});
+            config = ycb.read({region: 'fr'});
+            cmp(config, {val1:1, val5:1, val2:1, val4:1});
+            config = ycb.read({region: 'fr', flavor: 'att'});
+            cmp(config, {val1:1, val5:1, val2:1, val4:1, val3:1});
+        });
+
         it('should handle multi-level matching', function () {
             var bundle,
                 ycb,


### PR DESCRIPTION
Fix backwards compatibility case.
For a setting `["region:us", "lang:en,*"]` prior versions of YCB will log a warning that `*` is an invalid value but still use it as a wildcard, i.e., adding config at `us/en` and `us/*`.
Current version drops the wildcard path in the comma separated multi-value case.

This change will match prior version behavior.

<!-- The following line must be included in your pull request -->
---
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
