### PR TITLE
Add dimsUsed property

### DIFF
--- a/index.js
+++ b/index.js
@@ -1088,7 +1088,23 @@ Ycb.prototype = {
      */
     getDimensions: function() {
         return cloneDeep(this.dimensions);
-    }
+    },
+
+    /**
+     * Generate dimsUsed property matching format used by YCB 1.x.x.
+     * Precaution for backwards compability. Not expected to be called by client code so we generate it lazily.
+     * @returns {object}
+     */
+    get dimsUsed() {
+        var used = {};
+        Object.keys(this.valueToNumber).forEach((dim) => {
+            used[dim] = {};
+            Object.keys(this.valueToNumber[dim]).forEach((val) => {
+                used[dim][val] = true;
+            })
+        });
+        return used;
+    },
 };
 
 


### PR DESCRIPTION
YCB 1.X had a property `dimsUsed`, we don't expect client code to have used this property but as a precaution for compatibility this adds it back.
The object matches the structure of `valueToNumber` with all leaf values converted to `true`.

---
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
