### PR TITLE
feat: add typescript types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,58 @@
+type Bundle<T> = Array<Main<T> | Delta<T> | { dimensions: [{ [dimension: string]: Dimension }] }>;
+
+type Context = { [dimension: string]: string };
+
+type Delta<T> = {
+    settings: Settings<[`${string}:${string}`, ...Array<`${string}:${string}`>]>;
+} & DeepPartial<T>;
+
+type DeepPartial<T> = T extends object
+    ? {
+          [P in keyof T]?: DeepPartial<T[P]>;
+      }
+    : T;
+
+type Dimension = { [dimension: string]: Dimension | null };
+
+type Main<T> = { settings: Settings<['main' | 'master']> } & T;
+
+type Schedule = { start?: string; end?: string };
+
+type Settings<T> = T | { dimensions: T; schedule?: Schedule };
+
+declare module 'ycb' {
+    class Ycb<T extends Object> {
+        constructor(bundle: Bundle<T>, options?: { logContext?: string });
+        read(
+            context: Context,
+            options?: {
+                applySubstitutions?: boolean;
+            },
+        ): T;
+        readNoMerge(
+            context: Context,
+            options?: {
+                applySubstitutions?: boolean;
+            },
+        ): T[];
+        readTimeAware(
+            context: Context,
+            time: number,
+            options?: {
+                applySubstitutions?: boolean;
+                cacheInfo?: boolean;
+            },
+        ): T;
+        readNoMergeTimeAware(
+            context: Context,
+            time: number,
+            options?: {
+                applySubstitutions?: boolean;
+                cacheInfo?: boolean;
+            },
+        ): T[];
+    }
+
+    function read<T>(bundle: Bundle<T>, context: Context, validate?: boolean, debug?: boolean): T;
+    function readNoMerge<T>(bundle: Bundle<T>, context: Context, validate?: boolean, debug?: boolean): T;
+}

--- a/package.json
+++ b/package.json
@@ -2,8 +2,13 @@
     "name": "ycb",
     "version": "2.2.0",
     "description": "YCB is a multi-dimensional configuration library that builds bundles from resource files describing a variety of values.",
-    "author": "Ric Allinson <allinson@yahoo-inc.com>",
+    "bugs": "https://github.com/yahoo/ycb/issues",
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/yahoo/ycb.git"
+    },
     "license": "BSD",
+    "author": "Ric Allinson <allinson@yahoo-inc.com>",
     "contributors": [
         "Drew Folta <folta@yahoo-inc.com>",
         "Michael Ridgway <mridgway@yahoo-inc.com>",
@@ -11,6 +16,7 @@
         "Isao Yagi <isao@yahoo-inc.com>"
     ],
     "main": "index",
+    "types": "index.d.ts",
     "scripts": {
         "cover": "nyc npm run test",
         "lint": "eslint . && prettier --check .",
@@ -18,20 +24,15 @@
         "pretest": "npm run lint",
         "test": "mocha tests/unit --recursive --reporter spec"
     },
+    "prettier": {
+        "printWidth": 120,
+        "singleQuote": true,
+        "tabWidth": 4
+    },
     "devDependencies": {
         "eslint": "^9.0.0",
         "mocha": "^10.0.0",
         "nyc": "^17.0.0",
         "prettier": "^3.0.0"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/yahoo/ycb.git"
-    },
-    "bugs": "https://github.com/yahoo/ycb/issues",
-    "prettier": {
-        "printWidth": 120,
-        "singleQuote": true,
-        "tabWidth": 4
     }
 }


### PR DESCRIPTION
Adds typescript types while trying to maintain as much flexibility as possible.

```ts
type Config = { foo: string };
const ycb = new Ycb<Config>(bundle);
const { foo } = ycb.read(context); // foo is a string
```


While the examples show the `dimensions` and `main` config at the top, neither of those is required.

In fact, the `main` config is _technically_ not required. If you were to omit a main config, all you would get back is the delta, if any. I don't think this is how the library was intended to be used, and if you did want to omit the `main` config, you can give the generic type as a DeepPartial of your config, but this won't happen automatically.

```ts
type Config = DeepPartial<{ foo: string }>;
const ycb = new Ycb<<Config>>(bundle);
const { foo } = ycb.read(context); // foo is string | undefined
```

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
