### PR TITLE
feat: add support for Next.JS edge runtime

### DIFF
--- a/lib/isA.js
+++ b/lib/isA.js
@@ -1,3 +1,11 @@
 module.exports = function isA(item, constructor) {
+    if (constructor === Array) {
+        return Array.isArray(item);
+    }
+
+    if (constructor === Object) {
+        return item !== null && typeof item === 'object' && Array.isArray(item) !== true;
+    }
+
     return item && item.constructor === constructor;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "ycb",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "ycb",
-            "version": "2.2.0",
+            "version": "2.3.0",
             "license": "BSD",
             "devDependencies": {
                 "eslint": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ycb",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "description": "YCB is a multi-dimensional configuration library that builds bundles from resource files describing a variety of values.",
     "author": "Ric Allinson <allinson@yahoo-inc.com>",
     "license": "BSD",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "lint": "eslint . && prettier --check .",
         "lint:fix": "eslint . --fix && prettier --write .",
         "pretest": "npm run lint",
-        "test": "mocha tests/unit --recursive --reporter spec"
+        "test": "mocha tests/unit --recursive --reporter spec",
+        "posttest": "node -r ./tests/edgeRuntime.js ./node_modules/.bin/mocha tests/unit --recursive --reporter spec"
     },
     "devDependencies": {
         "eslint": "^9.0.0",

--- a/tests/edgeRuntime.js
+++ b/tests/edgeRuntime.js
@@ -1,0 +1,2 @@
+globalThis.Array = new Proxy(Array, {});
+globalThis.Object = new Proxy(Object, {});


### PR DESCRIPTION
Next.JS middleware's [Edge Runtime](https://nextjs.org/docs/app/api-reference/edge) has a proxy over the Object and Array making some of the type checks invalid in that environment invalid. This PR fixes that in a backward compatible way.

The existing tests are run in the default environment and then again in a `posttest` step with a (loosely) simulated edge runtime where Object and Array are proxied.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
